### PR TITLE
add inital configuration for ci tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.log
+*~
+/node_modules/

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -108,7 +108,6 @@
         "shorthand-property-no-redundant-values": true,
         "string-no-newline": true,
         "unit-no-unknown": true,
-        "value-list-comma-newline-after": "always-multi-line",
         "value-list-comma-space-after": "always-single-line",
         "value-list-comma-space-before": "never"
     }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,115 @@
+{
+    "rules": {
+        "at-rule-empty-line-before": [ "always", {
+            "except": [
+                "blockless-after-same-name-blockless",
+                "first-nested"
+            ],
+            "ignore": ["after-comment"]
+        }],
+        "at-rule-name-case": "lower",
+        "at-rule-name-space-after": "always-single-line",
+        "at-rule-semicolon-newline-after": "always",
+        "block-closing-brace-empty-line-before": "never",
+        "block-closing-brace-newline-after": "always",
+        "block-closing-brace-newline-before": "always-multi-line",
+        "block-closing-brace-space-before": "always-single-line",
+        "block-no-empty": true,
+        "block-opening-brace-newline-after": "always-multi-line",
+        "block-opening-brace-space-after": "always-single-line",
+        "block-opening-brace-space-before": "always",
+        "color-hex-case": "lower",
+        "color-hex-length": "short",
+        "color-no-invalid-hex": true,
+        "comment-empty-line-before": [ "always", {
+            "except": ["first-nested"],
+            "ignore": ["stylelint-commands"]
+        }],
+        "comment-no-empty": true,
+        "comment-whitespace-inside": "always",
+        "custom-property-empty-line-before": [ "always", {
+            "except": [
+                "after-custom-property",
+                "first-nested"
+            ],
+            "ignore": [
+                "after-comment",
+                "inside-single-line-block"
+            ]
+        }],
+        "declaration-bang-space-after": "never",
+        "declaration-bang-space-before": "always",
+        "declaration-block-no-ignored-properties": true,
+        "declaration-block-no-shorthand-property-overrides": true,
+        "declaration-block-semicolon-newline-after": "always-multi-line",
+        "declaration-block-semicolon-space-after": "always-single-line",
+        "declaration-block-semicolon-space-before": "never",
+        "declaration-block-single-line-max-declarations": 1,
+        "declaration-block-trailing-semicolon": "always",
+        "declaration-colon-newline-after": "always-multi-line",
+        "declaration-colon-space-after": "always-single-line",
+        "declaration-colon-space-before": "never",
+        "declaration-empty-line-before": [ "always", {
+            "except": [
+                "after-declaration",
+                "first-nested"
+            ],
+            "ignore": [
+                "after-comment",
+                "inside-single-line-block"
+            ]
+        }],
+        "function-calc-no-unspaced-operator": true,
+        "function-comma-newline-after": "always-multi-line",
+        "function-comma-space-after": "always-single-line",
+        "function-comma-space-before": "never",
+        "function-linear-gradient-no-nonstandard-direction": true,
+        "function-max-empty-lines": 0,
+        "function-parentheses-newline-inside": "always-multi-line",
+        "function-parentheses-space-inside": "never-single-line",
+        "function-whitespace-after": "always",
+        "indentation": 4,
+        "keyframe-declaration-no-important": true,
+        "length-zero-no-unit": true,
+        "max-empty-lines": 1,
+        "media-feature-colon-space-after": "always",
+        "media-feature-colon-space-before": "never",
+        "media-feature-no-missing-punctuation": true,
+        "media-feature-parentheses-space-inside": "never",
+        "media-feature-range-operator-space-after": "always",
+        "media-feature-range-operator-space-before": "always",
+        "media-query-list-comma-newline-after": "always-multi-line",
+        "media-query-list-comma-space-after": "always-single-line",
+        "media-query-list-comma-space-before": "never",
+        "no-empty-source": true,
+        "no-eol-whitespace": true,
+        "no-extra-semicolons": true,
+        "no-invalid-double-slash-comments": true,
+        "no-missing-end-of-source-newline": true,
+        "number-leading-zero": "always",
+        "number-no-trailing-zeros": true,
+        "rule-nested-empty-line-before": [ "always-multi-line", {
+            "except": ["first-nested"],
+            "ignore": ["after-comment"]
+        }],
+        "rule-non-nested-empty-line-before": [ "always-multi-line", {
+            "ignore": ["after-comment"]
+        }],
+        "selector-attribute-brackets-space-inside": "never",
+        "selector-attribute-operator-space-after": "never",
+        "selector-attribute-operator-space-before": "never",
+        "selector-combinator-space-after": "always",
+        "selector-combinator-space-before": "always",
+        "selector-list-comma-newline-after": "always",
+        "selector-list-comma-space-before": "never",
+        "selector-max-empty-lines": 0,
+        "selector-pseudo-class-parentheses-space-inside": "never",
+        "selector-pseudo-element-colon-notation": "double",
+        "shorthand-property-no-redundant-values": true,
+        "string-no-newline": true,
+        "unit-no-unknown": true,
+        "value-list-comma-newline-after": "always-multi-line",
+        "value-list-comma-space-after": "always-single-line",
+        "value-list-comma-space-before": "never"
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+
+node_js:
+    - "node"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "stylesheet",
+  "version": "5.0.1",
+  "description": "The Gtk+ Stylesheet for elementary OS",
+  "main": "index.theme",
+  "scripts": {
+    "test": "stylelint **/*.css"
+  },
+  "devDependencies": {
+    "stylelint": "^7.2.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elementary/stylesheet.git"
+  },
+  "license": "GPL-3.0",
+  "bugs": {
+    "url": "https://github.com/elementary/stylesheet/issues"
+  },
+  "homepage": "https://github.com/elementary/stylesheet#readme"
+}


### PR DESCRIPTION
This adds `stylelint` package for CSS linting. I used the same configuration that elementary/website uses minus a couple of settings that interfere with GTK.

For testing locally you will need `npm` installed. If you have done any work on website, or node projects this should already be installed. Then run `npm install` to grab `stylelint`. You will only need to do this once. Then run `npm test` and it will lint all the CSS files.