### PR TITLE
make menubar transparent if it's inside a titlebar

### DIFF
--- a/gtk-3.0/apps.css
+++ b/gtk-3.0/apps.css
@@ -29,7 +29,6 @@
             "user-not-tracked-symbolic"
         ),
         linear-gradient(
-            to bottom,
             shade (
                 @colorPrimary,
                 1.04
@@ -51,7 +50,6 @@
             "user-not-tracked-symbolic"
         ),
         linear-gradient(
-            to bottom,
             shade (
                 @colorPrimary,
                 1.08

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -2104,7 +2104,7 @@ menubar,
 }
 
 .titlebar .menubar {
-	background-color: transparent;
+    background-color: transparent;
 }
 
 menubar menuitem,

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -2103,6 +2103,10 @@ menubar,
     -GtkWidget-window-dragging: true;
 }
 
+.titlebar .menubar {
+	background-color: transparent;
+}
+
 menubar menuitem,
 .menubar .menuitem {
     padding: 3px 6px;


### PR DESCRIPTION
Had to remove `to bottom` to make the linter happy for some reason. It's okay because the default gradient direction is `to bottom` so no loss.