### PR TITLE
Default decoration

### DIFF
--- a/gtk-3.0/apps.css
+++ b/gtk-3.0/apps.css
@@ -289,6 +289,12 @@ ConversationListView.view.cell:selected:focus {
     background-color: alpha(#000, 0.5);
 }
 
+.panel menubar,
+.panel .menubar {
+    box-shadow: none;
+    border: none;
+}
+
 .composited-indicator > revealer label,
 .composited-indicator > revealer image,
 .composited-indicator > GtkRevealer {

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -2316,7 +2316,7 @@ radio:checked:focus,
 toolbar,
 .toolbar {
     -GtkWidget-window-dragging: true;
-    padding: 0 3px 3px;
+    padding: 3px;
     border: 1px solid shade (@titlebar_color, 0.56);
     border-width: 0 0 1px;
     box-shadow: inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.2);

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -2111,7 +2111,7 @@ menubar,
 menubar:backdrop,
 .menubar:backdrop {
     background-color: shade (@titlebar_color, 0.98);
-    border: 1px solid shade (@titlebar_color, 0.68);
+    border-color: shade (@titlebar_color, 0.78);
 }
 
 .titlebar .menubar {
@@ -2348,7 +2348,9 @@ toolbar:backdrop,
     background-color: shade (@titlebar_color, 0.98);
     background-image: none;
     border-color: shade (@titlebar_color, 0.64);
-    box-shadow: inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.4);
+    box-shadow:
+        inset 0 1px 0 0 alpha (@bg_highlight_color, 0.2),
+        inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.4);
     -gtk-image-effect: dim;
 }
 

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -4074,7 +4074,7 @@ GcrCertificateWidget .frame {
 }
 
 .titlebar.default-decoration:backdrop {
-    border-color: shade (@titlebar_color, 0.78)
+    border-color: shade (@titlebar_color, 0.78);
 }
 
 dialog .titlebar.default-decoration,

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -2100,13 +2100,18 @@ menubar,
 .menubar {
     color: @text_color;
     background-color: shade (@titlebar_color, 0.88);
-    box-shadow: inset 0 1px 0 0 alpha (@bg_highlight_color, 0.2);
+    border: 1px solid shade (@titlebar_color, 0.58);
+    border-width: 0 0 1px;
+    box-shadow:
+        inset 0 1px 0 0 alpha (@bg_highlight_color, 0.2),
+        inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.2);
     -GtkWidget-window-dragging: true;
 }
 
 menubar:backdrop,
 .menubar:backdrop {
     background-color: shade (@titlebar_color, 0.98);
+    border: 1px solid shade (@titlebar_color, 0.68);
 }
 
 .titlebar .menubar {
@@ -2319,7 +2324,9 @@ toolbar,
     padding: 3px;
     border: 1px solid shade (@titlebar_color, 0.56);
     border-width: 0 0 1px;
-    box-shadow: inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.2);
+    box-shadow:
+        inset 0 1px 0 0 alpha (@bg_highlight_color, 0.2),
+        inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.2);
     background-image:
         linear-gradient(
             to bottom,

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -2099,8 +2099,14 @@ menu,
 menubar,
 .menubar {
     color: @text_color;
-    background-color: @titlebar_color;
+    background-color: shade (@titlebar_color, 0.88);
+    box-shadow: inset 0 1px 0 0 alpha (@bg_highlight_color, 0.2);
     -GtkWidget-window-dragging: true;
+}
+
+menubar:backdrop,
+.menubar:backdrop {
+    background-color: shade (@titlebar_color, 0.98);
 }
 
 .titlebar .menubar {
@@ -2317,7 +2323,10 @@ toolbar,
     background-image:
         linear-gradient(
             to bottom,
-            @titlebar_color,
+            shade (
+                @titlebar_color,
+                0.88
+            ),
             shade (
                 @titlebar_color,
                 0.84
@@ -2329,15 +2338,8 @@ toolbar,
 
 toolbar:backdrop,
 .toolbar:backdrop {
-    background-image:
-        linear-gradient(
-            to bottom,
-            @titlebar_color,
-            shade (
-                @titlebar_color,
-                0.98
-            )
-        );
+    background-color: shade (@titlebar_color, 0.98);
+    background-image: none;
     border-color: shade (@titlebar_color, 0.64);
     box-shadow: inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.4);
     -gtk-image-effect: dim;
@@ -4069,6 +4071,10 @@ GcrCertificateWidget .frame {
 
 .titlebar.default-decoration {
     padding: 4px 3px;
+}
+
+.titlebar.default-decoration:backdrop {
+    border-color: shade (@titlebar_color, 0.78)
 }
 
 dialog .titlebar.default-decoration,

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -4068,18 +4068,7 @@ GcrCertificateWidget .frame {
 }
 
 .titlebar.default-decoration {
-    padding: 1px 3px;
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @titlebar_color,
-                1.04
-            ),
-            @titlebar_color
-        );
-    border-width: 0;
-    box-shadow: inset 0 1px 0 0 alpha (@bg_highlight_color, 0.6);
+    padding: 4px 3px;
 }
 
 dialog .titlebar.default-decoration,
@@ -4095,6 +4084,7 @@ GtkMessageDialog .titlebar.default-decoration {
         inset 1px 0 0 0 alpha (@bg_highlight_color, 0.2),
         inset -1px 0 0 0 alpha (@bg_highlight_color, 0.2),
         inset 0 1px 0 0 @bg_highlight_color;
+    padding: 1px 3px;
 }
 
 dialog .titlebar:backdrop,


### PR DESCRIPTION
This branch changes the style of `default-decoration` to match that of `titlebar.compact`.

Up until this point, the stylesheet has been mostly built around the assumption that a titlebar has a toolbar below it. However, this isn't always the case. Changing the style in this way should make some non-native apps look nicer as well as not require the explicit use of `Gtk.Headerbar` if no toolbar is needed.

Please test this branch thoroughly for adverse effects before merging :)

**Before:**

![screenshot from 2017-01-04 15 17 57](https://cloud.githubusercontent.com/assets/7277719/21662823/02348e80-d291-11e6-9ed6-b47f7e1ebbc6.png)

**After:**

![screenshot from 2017-01-04 15 17 41](https://cloud.githubusercontent.com/assets/7277719/21662831/0b6c0f78-d291-11e6-8b47-38341a3d3a2d.png)
