### PR TITLE
remove Terminal CSS

### DIFF
--- a/gtk-3.0/apps.css
+++ b/gtk-3.0/apps.css
@@ -433,11 +433,3 @@ ConversationListView.view.cell:selected:focus {
     color: @selected_fg_color;
     text-shadow: none;
 }
-
-/************
- * Terminal *
- ***********/
-
-PantheonTerminalPantheonTerminalWindow.background {
-    background-color: transparent;
-}


### PR DESCRIPTION
Depends on having a Terminal release that [contains this fix](https://code.launchpad.net/~elementary-apps/pantheon-terminal/background-css/+merge/315308)