### PR TITLE
Give stackswitcher image buttons in titlebars a border

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -1053,7 +1053,8 @@ GtkComboBox.combobox-entry .button {
 button,
 actionbar button.text-button,
 .button,
-.action-bar .button.text-button {
+.action-bar .button.text-button,
+.titlebar .stack-switcher .button.image-button {
     text-shadow: 0 1px @text_shadow_color;
     icon-shadow: 0 1px @text_shadow_color;
     background-image:
@@ -1123,14 +1124,16 @@ toolbar button,
 }
 
 button:hover,
-.button:hover {
+.button:hover,
+.titlebar .stack-switcher .button.image-button:hover {
     color: @text_color;
 }
 
 button:focus,
 popover actionbar button:focus,
 .button:focus,
-.popover .action-bar .button:focus {
+.popover .action-bar .button:focus,
+.titlebar .stack-switcher .button.image-button:focus {
     color: @text_color;
     border-color: @colorAccent;
     box-shadow:
@@ -1207,7 +1210,11 @@ button:focus:checked,
 .button:hover:checked,
 .button:focus:checked,
 .titlebar .titlebutton:active, /* Mutter needs this exact match*/
-.action-bar .button.suggested-action.text-button:active {
+.action-bar .button.suggested-action.text-button:active,
+.titlebar .stack-switcher .button.image-button:active,
+.titlebar .stack-switcher .button.image-button:hover:active,
+.titlebar .stack-switcher .button.image-button:checked,
+.titlebar .stack-switcher .button.image-button:hover:checked {
     background-color: alpha (#000, 0.05);
     background-image: none;
     border-color: alpha (#000, 0.27);
@@ -1660,7 +1667,8 @@ GtkComboBox.combobox-entry .button:last-child {
 .linked button,
 .linked .entry,
 .linked .button,
-.linked > GtkComboBox .button.the-button-in-the-combobox {
+.linked > GtkComboBox .button.the-button-in-the-combobox,
+.titlebar .stack-switcher .button.image-button {
     border-left-width: 0;
     border-radius: 0;
 }
@@ -1670,7 +1678,8 @@ GtkComboBox.combobox-entry .button:last-child {
 .linked button:first-child,
 .linked .entry:first-child,
 .linked .button:first-child,
-.linked > GtkComboBox:first-child > .button.the-button-in-the-combobox {
+.linked > GtkComboBox:first-child > .button.the-button-in-the-combobox,
+.titlebar .stack-switcher .button.image-button:first-child {
     border-width: 1px;
     border-bottom-right-radius: 0;
     border-top-right-radius: 0;
@@ -1683,7 +1692,8 @@ GtkComboBox.combobox-entry .button:last-child {
 .linked button:last-child,
 .linked .entry:last-child,
 .linked .button:last-child,
-.linked > GtkComboBox:last-child > .button.the-button-in-the-combobox {
+.linked > GtkComboBox:last-child > .button.the-button-in-the-combobox,
+.titlebar .stack-switcher .button.image-button:last-child {
     border-left-width: 0;
     border-bottom-right-radius: 2.5px;
     border-top-right-radius: 2.5px;
@@ -1696,7 +1706,8 @@ GtkComboBox.combobox-entry .button:last-child {
 .linked button:only-child,
 .linked .entry:only-child,
 .linked .button:only-child,
-.linked > GtkComboBox:only-child > .button.the-button-in-the-combobox {
+.linked > GtkComboBox:only-child > .button.the-button-in-the-combobox,
+.titlebar .stack-switcher .button.image-button:only-child {
     border-right-width: 1px;
     border-left-width: 1px;
     border-radius: 2.5px;


### PR DESCRIPTION
Fixes #69 

Just some ridiculous specificity stuff we have to do because `:not` isn't a thing in gtk3.18