### PR TITLE
set card border to transparent to fix glitchy border transitions

### DIFF
--- a/gtk-3.0/granite-widgets.css
+++ b/gtk-3.0/granite-widgets.css
@@ -110,6 +110,7 @@
 .card {
     background-color: @base_color;
     border: none;
+    border-color: transparent;
     box-shadow:
         0 0 0 1px alpha (#000, 0.05),
         0 3px 3px alpha (#000, 0.22);


### PR DESCRIPTION
This fixes a glitch where the border will transition from black once the element is :checked 