### PR TITLE
Make InfoBar flatter

### DIFF
--- a/gtk-3.0/granite-widgets.css
+++ b/gtk-3.0/granite-widgets.css
@@ -113,8 +113,7 @@
     border-color: transparent;
     box-shadow:
         0 0 0 1px alpha (#000, 0.05),
-        0 1px 2px -1px alpha (#000, 0.3),
-        0 3px 4px alpha (#000, 0.2);
+        0 3px 3px alpha (#000, 0.22);
     transition: all 150ms ease-in-out;
 }
 

--- a/gtk-3.0/granite-widgets.css
+++ b/gtk-3.0/granite-widgets.css
@@ -110,6 +110,7 @@
 .card {
     background-color: @base_color;
     border: none;
+    border-color: transparent;
     box-shadow:
         0 0 0 1px alpha (#000, 0.05),
         0 3px 3px alpha (#000, 0.22);

--- a/gtk-3.0/granite-widgets.css
+++ b/gtk-3.0/granite-widgets.css
@@ -113,7 +113,8 @@
     border-color: transparent;
     box-shadow:
         0 0 0 1px alpha (#000, 0.05),
-        0 3px 3px alpha (#000, 0.22);
+        0 1px 2px -1px alpha (#000, 0.3),
+        0 3px 4px alpha (#000, 0.2);
     transition: all 150ms ease-in-out;
 }
 

--- a/gtk-3.0/gtk-widgets-dark.css
+++ b/gtk-3.0/gtk-widgets-dark.css
@@ -890,57 +890,6 @@ EggListBox {
 * GtkInfoBar *
 *************/
 
-GtkInfoBar.info,
-GtkInfoBar.question,
-GtkInfoBar.warning,
-GtkInfoBar.error {
-    border-style: solid;
-    box-shadow:
-        inset 0 1px 0 0 alpha (#fff, 0.3),
-        inset 0 -1px 0 0 alpha (#fff, 0.06);
-}
-
-GtkInfoBar.info {
-    box-shadow:
-        inset 0 1px 0 0 alpha (#fff, 0.15),
-        inset 0 -1px 0 0 alpha (#fff, 0.03);
-}
-
-GtkInfoBar.question {
-    background-image:
-        linear-gradient(
-            to bottom,
-            #55c1ec,
-            #44a2e9
-        );
-    border-color: #357fb8;
-}
-
-GtkInfoBar.warning {
-    background-image:
-        linear-gradient(
-            to bottom,
-            #fdde76,
-            #fbd058
-        );
-    border-color: #c09e42;
-}
-
-GtkInfoBar.error {
-    background-image:
-        linear-gradient(
-            to bottom,
-            #e35d4f,
-            #d33f3d
-        );
-    border-color: #a2302e;
-}
-
-GtkInfoBar GtkLabel {
-    icon-shadow: 0 1px alpha (#fff, 0.3);
-    text-shadow: 0 1px alpha (#fff, 0.3);
-}
-
 GtkInfoBar .button,
 GtkInfoBar .button:focus,
 .dynamic-notebook GtkInfoBar .button {

--- a/gtk-3.0/gtk-widgets-dark.css
+++ b/gtk-3.0/gtk-widgets-dark.css
@@ -890,6 +890,22 @@ EggListBox {
 * GtkInfoBar *
 *************/
 
+infobar.error button,
+GtkInfoBar.error .button {
+    color: #fff;
+    text-shadow: 0 1px 1px @error_color;
+}
+
+infobar.question button,
+GtkInfoBar.question .button {
+    color: shade (@selected_bg_color, 0.25);
+}
+
+infobar.warning button,
+GtkInfoBar.warning .button {
+    color: shade (@warning_color, 0.25);
+}
+
 GtkInfoBar .button,
 GtkInfoBar .button:focus,
 .dynamic-notebook GtkInfoBar .button {

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3831,6 +3831,10 @@ GtkInfoBar .button:focus,
     text-shadow: none;
 }
 
+GtkInfoBar .button .label {
+    padding: 0 6px;
+}
+
 infobar button:insensitive,
 infobar button:hover:insensitive,
 GtkInfoBar .button:insensitive,

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3740,11 +3740,13 @@ GtkCalendar.highlight {
 
 infobar,
 GtkInfoBar {
+    background-color: @base_color;
+    border-color: shade (@base_color, 0.8);
     border-style: solid;
     border-width: 0 0 1px;
     box-shadow:
-        inset 0 1px 0 0 alpha (#fff, 0.3),
-        inset 0 -1px 0 0 alpha (#fff, 0.06);
+        inset 0 1px 0 0 @base_color,
+        inset 0 -1px 0 0 alpha (#fff, 0.3);
 }
 
 infobar.frame,
@@ -3759,112 +3761,46 @@ GtkInfoBar.frame {
 }
 
 infobar label,
-GtkInfoBar GtkLabel {
-    padding: 3px;
-}
-
-infobar.info,
-GtkInfoBar.info {
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @bg_color,
-                1.01
-            ),
-            shade (
-                @bg_color,
-                0.97
-            )
-        );
-    box-shadow:
-        inset 0 1px 0 0 #fff,
-        inset 0 -1px 0 0 alpha (#fff, 0.4);
-    border-color: shade (@bg_color, 0.8);
-}
-
-infobar.info label,
-infobar.info image,
-GtkInfoBar.info GtkLabel {
+GtkInfoBar .label {
     color: @text_color;
-}
-
-infobar.question,
-GtkInfoBar.question {
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @selected_bg_color,
-                1.3
-            ),
-            @selected_bg_color
-        );
-    border-color: shade (@selected_bg_color, 0.9);
-}
-
-infobar.question label,
-infobar.question image,
-GtkInfoBar.question GtkLabel {
-    color: shade (@selected_bg_color, 0.5);
-}
-
-infobar.warning,
-GtkInfoBar.warning {
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @warning_color,
-                1.3
-            ),
-            @warning_color
-        );
-    box-shadow:
-        inset 0 1px 0 0 alpha (#fff, 0.4),
-        inset 0 -1px 0 0 alpha (#fff, 0.25);
-    border-color: shade (@warning_color, 0.8);
-}
-
-infobar.warning.frame,
-GtkInfoBar.warning.frame {
-    box-shadow:
-        inset 0 0 0 1px alpha (#fff, 0.05),
-        inset 0 1px 0 0 alpha (#fff, 0.55),
-        inset 0 -1px 0 0 alpha (#fff, 0.15),
-        0 1px 1px alpha (#000, 0.03),
-        0 1px 2px alpha (#000, 0.1);
-}
-
-infobar.warning label,
-infobar.warning image,
-GtkInfoBar.warning GtkLabel {
-    color: shade (@warning_color, 0.5);
+    padding: 3px;
 }
 
 infobar.error,
 GtkInfoBar.error {
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @error_color,
-                1.3
-            ),
-            @error_color
-        );
-    border-color: shade (@error_color, 0.9);
+    background-color:shade (@error_color, 1.2);
+    border-color: shade (@error_color, 0.8);
+    box-shadow: inset 0 -1px 0 0 alpha (#fff, 0.3);
 }
 
 infobar.error label,
-GtkInfoBar.error GtkLabel {
-    color: shade (@error_color, 0.5);
+GtkInfoBar.error .label{
+    color: #fff;
+    text-shadow: 0 1px 1px @error_color;
 }
 
-infobar label,
-GtkInfoBar GtkLabel {
-    icon-shadow: 0 1px alpha (#fff, 0.3);
-    text-shadow: 0 1px alpha (#fff, 0.3);
+infobar.question,
+GtkInfoBar.question {
+    background-color:shade (@selected_bg_color, 1.2);
+    border-color: shade (@selected_bg_color, 0.8);
+    box-shadow: inset 0 -1px 0 0 alpha (#fff, 0.3);
+}
+
+infobar.question label,
+GtkInfoBar.question .label{
+    color: shade (@selected_bg_color, 0.25);
+}
+
+infobar.warning,
+GtkInfoBar.warning {
+    background-color:shade (@warning_color, 1.2);
+    border-color: shade (@warning_color, 0.8);
+    box-shadow: inset 0 -1px 0 0 alpha (#fff, 0.5);
+}
+
+infobar.warning label,
+GtkInfoBar.warning .label{
+    color: shade (@warning_color, 0.25);
 }
 
 infoBar entry,
@@ -3885,34 +3821,15 @@ infoBar button:focus,
 GtkInfoBar .button,
 GtkInfoBar .button:focus,
 .notebook GtkInfoBar .button {
-    text-shadow: none;
-    icon-shadow: none;
-    background-image: none;
-    background-color: transparent;
     border: 1px solid alpha (#000, 0.3);
-    box-shadow:
-        inset 0 0 0 1px alpha (#fff, 0.05),
-        inset 0 1px 0 0 alpha (#fff, 0.45),
-        inset 0 -1px 0 0 alpha (#fff, 0.15),
-        0 1px 0 0 alpha (#fff, 0.15);
-}
-
-infobar button:active,
-infobar button:hover:active,
-GtkInfoBar .button:active,
-GtkInfoBar .button:hover:active {
-    background-image: none;
-    background-color: alpha (#000, 0.05);
-    border-color: alpha (#000, 0.35);
+    text-shadow: none;
 }
 
 infobar button:insensitive,
 infobar button:hover:insensitive,
 GtkInfoBar .button:insensitive,
 GtkInfoBar .button:hover:insensitive {
-    background-image: none;
-    background-color: transparent;
-    border-color: alpha (#000, 0.18);
+    opacity: 0.7;
 }
 
 /***********

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3768,7 +3768,7 @@ GtkInfoBar .label {
 
 infobar.error,
 GtkInfoBar.error {
-    background-color:shade (@error_color, 1.2);
+    background-color: shade (@error_color, 1.2);
     border-color: shade (@error_color, 0.8);
     box-shadow:
         inset 0 1px 0 0 alpha (@error_color, 0.3),
@@ -3776,14 +3776,14 @@ GtkInfoBar.error {
 }
 
 infobar.error label,
-GtkInfoBar.error .label{
+GtkInfoBar.error .label {
     color: #fff;
     text-shadow: 0 1px 1px @error_color;
 }
 
 infobar.question,
 GtkInfoBar.question {
-    background-color:shade (@selected_bg_color, 1.2);
+    background-color: shade (@selected_bg_color, 1.2);
     border-color: shade (@selected_bg_color, 0.8);
     box-shadow:
         inset 0 1px 0 0 alpha (@selected_bg_color, 0.3),
@@ -3791,13 +3791,13 @@ GtkInfoBar.question {
 }
 
 infobar.question label,
-GtkInfoBar.question .label{
+GtkInfoBar.question .label {
     color: shade (@selected_bg_color, 0.25);
 }
 
 infobar.warning,
 GtkInfoBar.warning {
-    background-color:shade (@warning_color, 1.2);
+    background-color: shade (@warning_color, 1.2);
     border-color: shade (@warning_color, 0.8);
     box-shadow:
         inset 0 1px 0 0 alpha (@warning_color, 0.3),
@@ -3805,7 +3805,7 @@ GtkInfoBar.warning {
 }
 
 infobar.warning label,
-GtkInfoBar.warning .label{
+GtkInfoBar.warning .label {
     color: shade (@warning_color, 0.25);
 }
 

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3745,8 +3745,8 @@ GtkInfoBar {
     border-style: solid;
     border-width: 0 0 1px;
     box-shadow:
-        inset 0 1px 0 0 @base_color,
-        inset 0 -1px 0 0 alpha (#fff, 0.3);
+        inset 0 1px 0 0 shade (@base_color, 0.9),
+        inset 0 -1px 0 0 shade (@base_color, 1.2);
 }
 
 infobar.frame,
@@ -3770,7 +3770,9 @@ infobar.error,
 GtkInfoBar.error {
     background-color:shade (@error_color, 1.2);
     border-color: shade (@error_color, 0.8);
-    box-shadow: inset 0 -1px 0 0 alpha (#fff, 0.3);
+    box-shadow:
+        inset 0 1px 0 0 alpha (@error_color, 0.3),
+        inset 0 -1px 0 0 alpha (#fff, 0.3);
 }
 
 infobar.error label,
@@ -3783,7 +3785,9 @@ infobar.question,
 GtkInfoBar.question {
     background-color:shade (@selected_bg_color, 1.2);
     border-color: shade (@selected_bg_color, 0.8);
-    box-shadow: inset 0 -1px 0 0 alpha (#fff, 0.3);
+    box-shadow:
+        inset 0 1px 0 0 alpha (@selected_bg_color, 0.3),
+        inset 0 -1px 0 0 alpha (#fff, 0.3);
 }
 
 infobar.question label,
@@ -3795,7 +3799,9 @@ infobar.warning,
 GtkInfoBar.warning {
     background-color:shade (@warning_color, 1.2);
     border-color: shade (@warning_color, 0.8);
-    box-shadow: inset 0 -1px 0 0 alpha (#fff, 0.5);
+    box-shadow:
+        inset 0 1px 0 0 alpha (@warning_color, 0.3),
+        inset 0 -1px 0 0 alpha (#fff, 0.5);
 }
 
 infobar.warning label,


### PR DESCRIPTION
* Greatly reduces lines of code used to draw infobars
* Flatter design
* Fixes close button color in dark stylesheet
* Fixes text shadow in dark stylesheet
* Fixes #75 

Before:

![screenshot from 2017-03-21 13 31 38](https://cloud.githubusercontent.com/assets/7277719/24166972/c087bf12-0e3a-11e7-8407-c3852e2cc255.png)
![screenshot from 2017-03-21 13 31 47](https://cloud.githubusercontent.com/assets/7277719/24166971/c0868da4-0e3a-11e7-95a0-068aae01434b.png)

After:

![screenshot from 2017-03-21 13 32 07](https://cloud.githubusercontent.com/assets/7277719/24167009/d46b8374-0e3a-11e7-8904-c484c1d8b783.png)
![screenshot from 2017-03-21 13 32 17](https://cloud.githubusercontent.com/assets/7277719/24167008/d46a2484-0e3a-11e7-95aa-f2601837e6a5.png)

