### PR TITLE
Refine infobar styles

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3842,7 +3842,7 @@ GtkInfoBar.warning {
 
 infobar.warning button,
 GtkInfoBar.warning .button {
-    border-color: shade (@warning_color, 0.9);
+    border-color: shade (@warning_color, 0.8);
 }
 
 infobar.warning button:backdrop,

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3805,7 +3805,7 @@ GtkInfoBar .label {
 infobar.error,
 GtkInfoBar.error {
     background-color: shade (@error_color, 1.2);
-    border-color: shade (@error_color, 0.8);
+    border-color: @error_color;
     box-shadow:
         inset 0 1px 0 0 alpha (@error_color, 0.3),
         inset 0 -1px 0 0 alpha (#fff, 0.3);
@@ -3820,7 +3820,7 @@ GtkInfoBar.error .label {
 infobar.question,
 GtkInfoBar.question {
     background-color: shade (@selected_bg_color, 1.2);
-    border-color: shade (@selected_bg_color, 0.8);
+    border-color: shade (@selected_bg_color, 0.9);
     box-shadow:
         inset 0 1px 0 0 alpha (@selected_bg_color, 0.3),
         inset 0 -1px 0 0 alpha (#fff, 0.3);
@@ -3834,10 +3834,20 @@ GtkInfoBar.question .label {
 infobar.warning,
 GtkInfoBar.warning {
     background-color: shade (@warning_color, 1.2);
-    border-color: shade (@warning_color, 0.8);
+    border-color: shade (@warning_color, 0.9);
     box-shadow:
-        inset 0 1px 0 0 alpha (@warning_color, 0.3),
-        inset 0 -1px 0 0 alpha (#fff, 0.5);
+        inset 0 1px 0 0 @warning_color,
+        inset 0 -1px 0 0 alpha (#fff, 0.4);
+}
+
+infobar.warning button,
+GtkInfoBar.warning .button {
+    border-color: shade (@warning_color, 0.9);
+}
+
+infobar.warning button:backdrop,
+GtkInfoBar.warning .button:backdrop {
+    border-color: shade (@warning_color, 0.9);
 }
 
 infobar.warning label,


### PR DESCRIPTION
Adjust border colors a bit. Use shade for warning button border to make the color less muddy looking.

Before:

![screenshot from 2017-03-25 16 46 47](https://cloud.githubusercontent.com/assets/7277719/24327036/a8308910-117a-11e7-816f-d4299970c2e2.png)

After:

![screenshot from 2017-03-25 16 46 30](https://cloud.githubusercontent.com/assets/7277719/24327040/b11b387c-117a-11e7-9350-39af058ab4ac.png)
