### PR TITLE
Infobar: Use bg color as default instead of base color

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3782,7 +3782,7 @@ GtkInfoBar {
     border-width: 0 0 1px;
     box-shadow:
         inset 0 1px 0 0 shade (@bg_color, 0.92),
-        inset 0 -1px 0 0 #fff;
+        inset 0 -1px 0 0 shade (@bg_color, 1.2);
 }
 
 infobar.frame,

--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3776,13 +3776,13 @@ GtkCalendar.highlight {
 
 infobar,
 GtkInfoBar {
-    background-color: @base_color;
-    border-color: shade (@base_color, 0.8);
+    background-color: @bg_color;
+    border-color: shade (@bg_color, 0.8);
     border-style: solid;
     border-width: 0 0 1px;
     box-shadow:
-        inset 0 1px 0 0 shade (@base_color, 0.9),
-        inset 0 -1px 0 0 shade (@base_color, 1.2);
+        inset 0 1px 0 0 shade (@bg_color, 0.92),
+        inset 0 -1px 0 0 #fff;
 }
 
 infobar.frame,


### PR DESCRIPTION
I made a mistake, base color looks weird.

Before:

![screenshot from 2017-04-03 09 51 52](https://cloud.githubusercontent.com/assets/7277719/24620631/3d62bf38-1853-11e7-96c3-60dd86c3ec22.png)

After:

![screenshot from 2017-04-03 09 51 39](https://cloud.githubusercontent.com/assets/7277719/24620639/427ce976-1853-11e7-99d9-734b3c741701.png)

