### PR TITLE
Add .monospace support

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -156,6 +156,10 @@ rubberband,
     margin: 3px;
 }
 
+.monospace {
+    font-family: monospace;
+}
+
 /**************
  * Separators *
  *************/


### PR DESCRIPTION
Not 100% where this belongs; it is an explicit property on Gtk.TextView but could also definitely be a class used on any widget. Added with the other misc stuff for now.

Fixes #94 