### PR TITLE
Fix aggressive clipping on popover.menu

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -3919,7 +3919,6 @@ popover.osd,
 .popover.osd {
     border-radius: 4px;
     border: 1px solid alpha (#000, 0.3);
-    background-clip: content-box;
     background-color: @bg_color;
     box-shadow:
         inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.5),


### PR DESCRIPTION
Fixes the background clipping in `popover.menu` as seen in gtk3-widget-factory