### PR TITLE
Images inherit color

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -416,37 +416,8 @@ entry.flat,
 * Symbolic images *
 *******************/
 
-image,
-image:selected,
-.image,
-.image:selected {
-    color: @internal_element_color;
-}
-
-image:hover,
-.image:hover {
-    color: @internal_element_prelight;
-}
-
-image:selected:focus,
-image:selected:hover,
-.image:selected:focus,
-.image:selected:hover {
-    color: @selected_fg_color;
-}
-
-view image,
-view image:hover,
-view image:selected,
-.view.image,
-.view.image:hover,
-.view.image:selected {
-    color: @view_symbolic_color;
-}
-
-view image:selected:focus,
-.view.image:selected:focus {
-    color: @selected_fg_color;
+image {
+    color: inherit;
 }
 
 /****************


### PR DESCRIPTION
We're going to inherit color unless we override in specific widgets. This fixes image color in AppCenter for example