### PR TITLE
Check, Radio: use icon-shadow

### DIFF
--- a/gtk-3.22/assets/check-active.svg
+++ b/gtk-3.22/assets/check-active.svg
@@ -51,11 +51,6 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="M 9.98658,1.7483203 12,3.5604103 5.23489,12.5 0,7.9899403 1.73154,5.6946303 4.79194,8.35235 Z"
-     id="path2922-6-6-0-9-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#2f78c7;fill-opacity:0.99215686;fill-rule:nonzero;stroke:none;stroke-width:0.84323651;marker:none;enable-background:accumulate"
-     inkscape:connector-curvature="0" />
-  <path
      d="M 9.98658,0.7479603 12,2.5600503 5.23489,11.49964 0,6.9895803 l 1.73154,-2.29531 3.0604,2.65772 z"
      id="path2922-6-6-0-9"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.84323651;marker:none;enable-background:accumulate"

--- a/gtk-3.22/assets/check-active@2.svg
+++ b/gtk-3.22/assets/check-active@2.svg
@@ -46,15 +46,10 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <path
-     d="M 19.97316,3.4966397 24,7.1208199 10.46978,25 0,15.97988 3.46308,11.38926 9.58388,16.7047 Z"
-     id="path2922-6-6-0-9-4"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#2f78c7;fill-opacity:0.99215686;fill-rule:nonzero;stroke:none;stroke-width:1.68647301;marker:none;enable-background:accumulate"
-     inkscape:connector-curvature="0" />
   <path
      d="M 19.97316,1.4959197 24,5.1200998 10.46978,22.99928 0,13.97916 3.46308,9.38854 l 6.1208,5.31544 z"
      id="path2922-6-6-0-9"

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -2195,6 +2195,7 @@ radio:checked {
         );
     border-color: shade (@colorAccent, 0.85);
     -gtk-icon-source: -gtk-scaled(url("assets/check-active.svg"), url("assets/check-active@2.svg"));
+    -gtk-icon-shadow: 0 1px 1px shade (@colorAccent, 0.85);
 }
 
 check:disabled,


### PR DESCRIPTION
Replaces icon shadow in the image with one in CSS. This means checkbox now fully respects `colorAccent`:

![screenshot from 2017-07-10 14 23 23](https://user-images.githubusercontent.com/7277719/28040706-7f9fc2ea-657b-11e7-82bb-ebc395031d37.png)
