### PR TITLE
Make pane sep style selector more specific

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -178,7 +178,7 @@ separator.vertical {
     min-width: 2px;
 }
 
-paned.vertical separator {
+paned.vertical > separator {
     background-image:
         linear-gradient(
             to bottom,
@@ -191,7 +191,7 @@ paned.vertical separator {
     min-height: 8px;
 }
 
-paned.horizontal separator {
+paned.horizontal > separator {
     background-image:
         linear-gradient(
             to right,


### PR DESCRIPTION
Make sure that we're selecting the separator that comes with the pane and not other separators inside each side of the pane