### PR TITLE
Don't apply button styles to menuitem buttons

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -973,7 +973,7 @@ GtkComboBox.combobox-entry .button {
     -GtkButton-default-border: 0;
 }
 
-button,
+button:not(.menuitem),
 .button,
 .titlebar .stack-switcher .button.image-button {
     text-shadow: 0 1px @text_shadow_color;
@@ -1117,7 +1117,7 @@ GtkDialog .button.flat.image-button:hover {
     background-color: alpha (@text_color, 0.7);
 }
 
-button:active,
+button:not(.menuitem):active,
 button:hover:active,
 button:focus:active,
 button:checked,


### PR DESCRIPTION
This applies to `button.menuitem` which we use to emulate menu items in popovers like wingpanel indicators. Prevents having to override button styles