### PR TITLE
select indicator, not the whole mark container

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -822,16 +822,16 @@ scale.vertical trough {
     margin: 0 7px;
 }
 
-scale mark {
-    background: mix (@bg_color, @text_color, 0.3);
+scale mark indicator {
+    color: mix (@bg_color, @text_color, 0.3);
 }
 
-scale.horizontal mark {
+scale.horizontal mark indicator {
     min-height: 6px;
     min-width: 1px;
 }
 
-scale.vertical mark {
+scale.vertical mark indicator {
     min-height: 1px;
     min-width: 6px;
 }


### PR DESCRIPTION
Fixes an incorrect selection. Turns out `mark` is actually a container that also can have a label in it