### PR TITLE
don't set radius in inline-toolbar

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -2334,7 +2334,6 @@ GtkDialog .action-bar {
 .inline-toolbar,
 .inline-toolbar:backdrop {
     border-color: shade (@bg_color, 0.75);
-    border-radius: 0;
     border-width: 0 1px 1px;
     box-shadow: none;
     background-color: @bg_color;


### PR DESCRIPTION
Fixes a bug with `window.rounded:backdrop .inline-toolbar`. Don't see any reason why we'd set border radius here since we should inherit radius from the element already