### PR TITLE
increase sidebar text contrast

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3508,7 +3508,7 @@ list row:selected:focus image,
 .source-list,
 .source-list.view {
     background-color: shade (@bg_color, 0.92);
-    color: mix (@titlebar_color, @text_color, 0.6);
+    color: mix (@bg_color, @text_color, 0.77);
     -gtk-icon-style: regular;
     -GtkTreeView-horizontal-separator: 1px;
     -GtkTreeView-vertical-separator: 6px;

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -3180,7 +3180,7 @@ row:selected:focus image {
 .source-list,
 .source-list.view {
     background-color: shade (@bg_color, 0.92);
-    color: mix (@titlebar_color, @text_color, 0.6);
+    color: mix (@bg_color, @text_color, 0.77);
     -gtk-icon-style: regular;
     -GtkTreeView-horizontal-separator: 1px;
     -GtkTreeView-vertical-separator: 6px;


### PR DESCRIPTION
Fixes #166 

Sidebar text color contrast now passes WCAG AAA. This branch fixes both Loki and Juno

Before:
![screenshot from 2017-07-29 09 41 37](https://user-images.githubusercontent.com/7277719/28746502-7176aaa0-7442-11e7-9364-b8eb5d50b521.png)

After:
![screenshot from 2017-07-29 09 41 11](https://user-images.githubusercontent.com/7277719/28746504-7b048542-7442-11e7-9aef-7e21057f3451.png)


