### PR TITLE
Make dark selector for popup more specific

### DIFF
--- a/gtk-3.22/gtk-widgets-dark.css
+++ b/gtk-3.22/gtk-widgets-dark.css
@@ -892,20 +892,20 @@ decoration,
         0 10px 10px rgba(0, 0, 0, 0.22);
 }
 
-.popup decoration,
+window.popup decoration,
 .window-frame.menu.csd,
 .window-frame.popup.csd {
     box-shadow:
-        0 0 0 1px alpha (#000, 0.6),
+        0 0 0 1px alpha (#000, 0.75),
         0 3px 6px alpha (#000, 0.16),
         0 3px 6px alpha (#000, 0.23);
 }
 
-menu .popup decoration,
+menu window.popup decoration,
 .menu .window-frame.menu.csd,
 .menu .window-frame.popup.csd {
     box-shadow:
-        0 0 0 1px alpha (#000, 0.6),
+        0 0 0 1px alpha (#000, 0.75),
         0 10px 20px alpha (#000, 0.19),
         0 6px 6px alpha (#000, 0.23);
 }


### PR DESCRIPTION
`.popup` class is used for more than just menus, so we need to be more specific that we're selecting menu "windows"

While we're here, make the outline a bit darker