### PR TITLE
Use new tiled classes

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -3672,8 +3672,20 @@ GcrCertificateWidget .frame {
     padding: 4px 6px 3px;
 }
 
-.tiled .titlebar {
-    border-radius: 0;
+.tiled-left.tiled-top:not(.maximized) .titlebar {
+    border-top-right-radius: 0;
+}
+
+.tiled-right.tiled-top:not(.maximized) .titlebar {
+    border-top-left-radius: 0;
+}
+
+.tiled-left.tiled-bottom:not(.maximized) actionbar {
+    border-bottom-right-radius: 0;
+}
+
+.tiled-right.tiled-bottom:not(.maximized) actionbar {
+    border-bottom-left-radius: 0;
 }
 
 .titlebar.default-decoration {


### PR DESCRIPTION
Mutter now gives us information about which side of the display a window is tiled against. Use that to fix a regression which caused square maximized windows and to only square the inside edges of windows

![screenshot from 2017-12-02 12 12 25](https://user-images.githubusercontent.com/7277719/33519362-19486744-d75a-11e7-8641-86141a1a2cd8.png)
