### PR TITLE
Added Silver100 to temperature scale

### DIFF
--- a/gtk-3.22/granite-widgets.css
+++ b/gtk-3.22/granite-widgets.css
@@ -417,6 +417,7 @@ scale.temperature trough {
         linear-gradient(
             to right,
             @BLUEBERRY_500,
+            @SILVER_100,
             @ORANGE_500
         );
 }
@@ -426,6 +427,7 @@ scale.temperature:dir(rtl) trough {
         linear-gradient(
             to left,
             @BLUEBERRY_500,
+            @SILVER_100,
             @ORANGE_500
         );
 }


### PR DESCRIPTION
Adds a Silver100 stop to the temperature scale to better reflect how temperature is being visualized on other platforms. Plus, the white just makes the transition look better :wink: 

Example: 
- http://content.hwigroup.net/images/products_xl/169930/18/philips-hue-connected-bulb-starter-pack-e27.jpg

## Before
![screenshot from 2017-12-30 20 17 34](https://user-images.githubusercontent.com/10786508/34458644-f4a87fc6-ed9f-11e7-919e-92ca2a588e4c.png)

## After
![screenshot from 2017-12-30 20 17 01](https://user-images.githubusercontent.com/10786508/34458645-f62b63e0-ed9f-11e7-8ded-24763a3851f5.png)
