### PR TITLE
misc dark style fixes

### DIFF
--- a/gtk-3.22/gtk-dark.css
+++ b/gtk-3.22/gtk-dark.css
@@ -99,7 +99,7 @@
 @define-color placeholder_text_color shade(@text_color, 0.8);
 @define-color selected_bg_color shade (@BLUEBERRY_300, 0.85);
 @define-color selected_fg_color white;
-@define-color text_color #c0c6c4;
+@define-color text_color @SILVER_100;
 @define-color text_shadow_color alpha (@BLACK_900, 0.4);
 @define-color titlebar_color shade (@base_color, 0.9);
 @define-color title_color shade (@text_color, 0.9);

--- a/gtk-3.22/gtk-widgets-dark.css
+++ b/gtk-3.22/gtk-widgets-dark.css
@@ -719,10 +719,6 @@ column-header .button:hover {
 * List Boxes *
 *************/
 
-EggListBox {
-    background-color: @base_color;
-}
-
 .list {
     background-color: @base_color;
 }

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -2291,20 +2291,21 @@ toolbar.bottom-toolbar button,
     box-shadow: none;
 }
 
-toolbar button.image-button image {
-    color: shade (@title_color, 0.75);
+.titlbar image,
+toolbar image {
+    color: mix (@titlebar_color, @text_color, 0.85);
     -gtk-icon-shadow: 0 1px @title_shadow_color;
 }
 
-.titlebar button.image-button image:disabled,
-toolbar button.image-button image:disabled {
+.titlebar image:disabled,
+toolbar image:disabled {
     color: @insensitive_color;
     -gtk-icon-effect: dim;
 }
 
-.titlebar button.image-button image:backdrop,
-toolbar button.image-button image:backdrop {
-    color: shade (@titlebar_color, 0.8);
+.titlebar image:backdrop,
+toolbar image:backdrop {
+    color: mix (@titlebar_color, @text_color, 0.5);
     -gtk-icon-shadow: none;
 }
 


### PR DESCRIPTION
* Use a color from the palette for text color
* Get rid of legacy selector `EggListBox`
* Use `mix` for toolbar  and titlebar image colors that work better on light and dark stylesheets
* Make the selector for toolbar and titlebar images less specific so that it keeps buttons and plain Gtk.Images matching