### PR TITLE
Fix menuitem image placement

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1900,8 +1900,8 @@ modelbutton label,
     padding: 3px;
 }
 
-menu menuitem image:first-child {
-	margin-left: -16px;
+menu:dir(ltr) menuitem image:first-child {
+    margin-left: -16px;
 }
 
 modelbutton {

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1900,6 +1900,10 @@ modelbutton label,
     padding: 3px;
 }
 
+menu menuitem image:first-child {
+	margin-left: -16px;
+}
+
 modelbutton {
     min-width: 150px;
     padding: 3px 12px;


### PR DESCRIPTION
Gtk.ImageMenuItem is now deprecated and the docs recommend packing images inside a container with the label. The problem is this fucks up the alignment, so here we do some CSS magic to fix it