### PR TITLE
Add a class to easy give text and images accent color

### DIFF
--- a/gtk-3.22/granite-widgets.css
+++ b/gtk-3.22/granite-widgets.css
@@ -379,6 +379,10 @@ window.rounded decoration {
 * Text Styles *
 **************/
 
+.accent {
+    color: @colorAccent;
+}
+
 .h1 {
     font-size: 24pt;
 }


### PR DESCRIPTION
Fixes #261 

Example:

![screenshot from 2018-01-28 23 11 16](https://user-images.githubusercontent.com/7277719/35497795-91f1dde4-0480-11e8-96d5-c94618e6aa92.png)
