### PR TITLE
Headerbar brand fixes

### DIFF
--- a/gtk-3.22/granite-widgets.css
+++ b/gtk-3.22/granite-widgets.css
@@ -379,10 +379,6 @@ window.rounded decoration {
 * Text Styles *
 **************/
 
-.accent {
-    color: @colorAccent;
-}
-
 .h1 {
     font-size: 24pt;
 }

--- a/gtk-3.22/granite-widgets.css
+++ b/gtk-3.22/granite-widgets.css
@@ -379,6 +379,10 @@ window.rounded decoration {
 * Text Styles *
 **************/
 
+.accent {
+    color: @colorAccent;
+}
+
 .h1 {
     font-size: 24pt;
 }

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -923,15 +923,14 @@ button label {
 
 .titlebar button,
 .titlebar .button {
-    color: shade (@textColorPrimary, 0.8);
-    border-color: alpha (#000, 0.27);
-
-    /* FIXME: causes problems with files pathbar */
-
-    /* box-shadow: inset 0 0 0 1px alpha (shade (@colorPrimary, 1.4), 0.05),
+    border-color: shade (@colorPrimary, 0.75);
+    color: @textColorPrimary;
+    text-shadow: 0 1px @textColorPrimaryShadow;
+    box-shadow: inset 0 0 0 1px alpha (shade (@colorPrimary, 1.4), 0.05),
                 inset 0 1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.45),
                 inset 0 -1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.15),
-                0 1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.3); */
+                0 1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.3);
+    -gtk-icon-shadow: 0 1px @textColorPrimaryShadow;
 }
 
 button.color {
@@ -959,12 +958,6 @@ toolbar button,
 .titlebar .button,
 .toolbar .button {
     padding: 3px;
-}
-
-button:hover,
-.button:hover,
-.titlebar .stack-switcher .button.image-button:hover {
-    color: @text_color;
 }
 
 button:focus,
@@ -1046,10 +1039,10 @@ button:focus:checked,
 .button:hover:checked,
 .button:focus:checked,
 .titlebar .titlebutton:active, /* Mutter needs this exact match*/
-.titlebar .stack-switcher .button.image-button:active,
-.titlebar .stack-switcher .button.image-button:hover:active,
-.titlebar .stack-switcher .button.image-button:checked,
-.titlebar .stack-switcher .button.image-button:hover:checked {
+.titlebar button:active,
+.titlebar .button:active,
+.titlebar button:checked,
+.titlebar .button:checked {
     background-color: alpha (#000, 0.05);
     background-image: none;
     border-color: alpha (#000, 0.27);
@@ -2162,6 +2155,21 @@ toolbar:backdrop,
     -gtk-icon-effect: dim;
 }
 
+toolbar image {
+    color: mix (@titlebar_color, @text_color, 0.85);
+    -gtk-icon-shadow: 0 1px @title_shadow_color;
+}
+
+toolbar image:disabled {
+    color: @insensitive_color;
+    -gtk-icon-effect: dim;
+}
+
+toolbar image:backdrop {    
+    color: mix (@titlebar_color, @text_color, 0.5);
+    -gtk-icon-shadow: none;
+}
+
 /*********************
 * Secondary Toolbars *
 *********************/
@@ -2289,24 +2297,6 @@ toolbar.bottom-toolbar button,
     background-color: alpha (@text_color, 0.15);
     border-color: transparent;
     box-shadow: none;
-}
-
-.titlebar image,
-toolbar image {
-    color: mix (@titlebar_color, @text_color, 0.85);
-    -gtk-icon-shadow: 0 1px @title_shadow_color;
-}
-
-.titlebar image:disabled,
-toolbar image:disabled {
-    color: @insensitive_color;
-    -gtk-icon-effect: dim;
-}
-
-.titlebar image:backdrop,
-toolbar image:backdrop {
-    color: mix (@titlebar_color, @text_color, 0.5);
-    -gtk-icon-shadow: none;
 }
 
 /***************
@@ -3664,7 +3654,7 @@ messagedialog .titlebar.default-decoration:backdrop {
 .titlebar .title,
 .titlebar .subtitle,
 .titlebar .titlebutton,
-.titlebar button.image-button image {
+.titlebar image {
     color: @textColorPrimary;
     text-shadow: 0 1px @textColorPrimaryShadow;
     -gtk-icon-shadow: 0 1px @textColorPrimaryShadow;
@@ -3693,7 +3683,7 @@ messagedialog .titlebar.default-decoration:backdrop {
 .titlebar .title:disabled,
 .titlebar .subtitle:disabled,
 .titlebar .titlebutton:disabled,
-.titlebar button.image-button image:disabled {
+.titlebar image:disabled {
     color: shade (@textColorPrimary, 1.5);
     text-shadow: 0 1px @textColorPrimaryShadow;
     -gtk-icon-shadow: 0 1px @textColorPrimaryShadow;
@@ -3702,7 +3692,7 @@ messagedialog .titlebar.default-decoration:backdrop {
 .titlebar .title:backdrop,
 .titlebar .subtitle:backdrop,
 .titlebar .titlebutton:backdrop,
-.titlebar button.image-button image:backdrop {
+.titlebar image:backdrop {
     color: mix (@textColorPrimary, @colorPrimary, 0.3);
     text-shadow: none;
     -gtk-icon-shadow: none;

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -926,10 +926,11 @@ button label {
     border-color: shade (@colorPrimary, 0.75);
     color: @textColorPrimary;
     text-shadow: 0 1px @textColorPrimaryShadow;
-    box-shadow: inset 0 0 0 1px alpha (shade (@colorPrimary, 1.4), 0.05),
-                inset 0 1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.45),
-                inset 0 -1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.15),
-                0 1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.3);
+    box-shadow:
+        inset 0 0 0 1px alpha (shade (@colorPrimary, 1.4), 0.05),
+        inset 0 1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.45),
+        inset 0 -1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.15),
+        0 1px 0 0 alpha (shade (@colorPrimary, 1.4), 0.3);
     -gtk-icon-shadow: 0 1px @textColorPrimaryShadow;
 }
 
@@ -2165,7 +2166,7 @@ toolbar image:disabled {
     -gtk-icon-effect: dim;
 }
 
-toolbar image:backdrop {    
+toolbar image:backdrop {
     color: mix (@titlebar_color, @text_color, 0.5);
     -gtk-icon-shadow: none;
 }

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -3833,6 +3833,13 @@ messagedialog .titlebar:backdrop {
         inset 0 1px 0 0 @bg_highlight_color;
 }
 
+dialog .titlebar image,
+dialog .titlebar label {
+    color: @title_color;
+    text-shadow: 0 1px @title_shadow_color;
+    -gtk-icon-shadow: 0 1px @title_shadow_color;
+}
+
 dialog .titlebar .title {
     color: transparent;
     font-size: 0;

--- a/gtk-3.22/gtk.css
+++ b/gtk-3.22/gtk.css
@@ -82,7 +82,7 @@
 /* Brand Colors */
 @define-color colorPrimary @titlebar_color;
 @define-color colorAccent @selected_bg_color;
-@define-color textColorPrimary shade (@colorPrimary, 0.5);
+@define-color textColorPrimary mix (@colorPrimary, @text_color, 0.75);
 @define-color textColorPrimaryShadow alpha (shade (@colorPrimary, 1.4), 0.4);
 
 /* Default color scheme */


### PR DESCRIPTION
Fixes #263

Fixes a bit of fuckery around setting the text color and button color for branded titlebars

**Before:**

![screenshot from 2018-01-30 20 51 52](https://user-images.githubusercontent.com/7277719/35605729-7e6e6668-05ff-11e8-96b5-77c01b249ece.png)


**After:**

![screenshot from 2018-01-30 20 52 10](https://user-images.githubusercontent.com/7277719/35605732-82c30afc-05ff-11e8-8f5f-88a4af20d6a5.png)
