### PR TITLE
Fix incorrect units on welcome buttons

### DIFF
--- a/gtk-3.22/granite-widgets.css
+++ b/gtk-3.22/granite-widgets.css
@@ -349,7 +349,7 @@
  **********/
 
 .welcome {
-    font-size: 10px;
+    font-size: 10pt;
     text-shadow: none;
 }
 


### PR DESCRIPTION
This fixes a regression from Loki to Juno with the description text size in welcome buttons

**Before:**

![screenshot from 2018-01-30 20 48 55](https://user-images.githubusercontent.com/7277719/35605672-1d9d03bc-05ff-11e8-9299-1dae2c31a853.png)


**After:**

![screenshot from 2018-01-30 20 49 22](https://user-images.githubusercontent.com/7277719/35605683-25945f02-05ff-11e8-9620-a38a4011bc2c.png)
