### PR TITLE
Fix GtkScale rounded borders and margin, show fill level

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -824,19 +824,39 @@ scale.vertical mark indicator {
 }
 
 scale highlight {
-    border-radius: 12px 0 0 12px;
     background-color: alpha (#000, 0.45);
-    margin: 0 -6px;
 }
 
 scale highlight:disabled {
-    border-radius: 12px 0 0 12px;
     background-color: alpha (#000, 0.25);
 }
 
-scale.vertical highlight {
+scale fill {
+    background-color: alpha(#000, 0.25);
+}
+
+scale.horizontal highlight.top,
+scale.horizontal fill.top {
+    border-radius: 12px 0 0 12px;
+    margin: 0 0 0 -6px;
+}
+
+scale.horizontal highlight.bottom,
+scale.horizontal fill.bottom {
+    border-radius: 0 12px 12px 0;
+    margin: 0 -6px 0 0;
+}
+
+scale.vertical highlight.top,
+scale.vertical fill.top {
     border-radius: 12px 12px 0 0;
-    margin: -6px 0;
+    margin: -6px 0 0 0;
+}
+
+scale.vertical highlight.bottom,
+scale.vertical fill.bottom {
+    border-radius: 0 0 12px 12px;
+    margin: 0 0 -6px 0;
 }
 
 /*********


### PR DESCRIPTION
* round correct corners for RTL or inverted widgets
* remove highlight margin for inner border for more accurate Granite Seekbar
* display fill level property, when set

before:
![screenshot from 2018-02-10 14 34 22](https://user-images.githubusercontent.com/805017/36062598-0674203e-0e70-11e8-84db-334f90764b4b.png)

after:
![screenshot from 2018-02-10 14 34 34](https://user-images.githubusercontent.com/805017/36062601-0f5b7b70-0e70-11e8-87cf-8b96b74a0a46.png)

This only fixes 3.22 version. There are similar issues for gtk-3.0. Is that version still active and should it be fixed? I haven't checked 2.0.

I'm not sure if style for fill level is ok, i just added some color to it so that it's displayed. And also since highlight is partly transparent, fill level makes it more dark.

Let me know if anyone wants code for this test app.