### PR TITLE
Define background for GtkTextView (fix #249)

### DIFF
--- a/gtk-3.22/gtk-widgets-dark.css
+++ b/gtk-3.22/gtk-widgets-dark.css
@@ -58,7 +58,7 @@ entry:focus,
         0 1px 0 0 alpha (#fff, 0.05);
 }
 
-textview text {
+textview, textview text {
     color: @text_color;
     background-color: @base_color;
 }

--- a/gtk-3.22/gtk-widgets-dark.css
+++ b/gtk-3.22/gtk-widgets-dark.css
@@ -58,6 +58,11 @@ entry:focus,
         0 1px 0 0 alpha (#fff, 0.05);
 }
 
+textview text {
+  color: @text_color;
+  background-color: @base_color;
+}
+
 entry selection,
 textview selection {
     color: shade (@text_color, 1.23);

--- a/gtk-3.22/gtk-widgets-dark.css
+++ b/gtk-3.22/gtk-widgets-dark.css
@@ -58,11 +58,6 @@ entry:focus,
         0 1px 0 0 alpha (#fff, 0.05);
 }
 
-textview, textview text {
-    color: @text_color;
-    background-color: @base_color;
-}
-
 entry selection,
 textview selection {
     color: shade (@text_color, 1.23);

--- a/gtk-3.22/gtk-widgets-dark.css
+++ b/gtk-3.22/gtk-widgets-dark.css
@@ -59,8 +59,8 @@ entry:focus,
 }
 
 textview text {
-  color: @text_color;
-  background-color: @base_color;
+    color: @text_color;
+    background-color: @base_color;
 }
 
 entry selection,

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -435,8 +435,8 @@ entry.flat,
  *************/
 
 textview text {
-  color: @text_color;
-  background-color: @base_color;
+    color: @text_color;
+    background-color: @base_color;
 }
 
 /*******************

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -430,6 +430,15 @@ entry.flat,
     box-shadow: none;
 }
 
+/*************
+ * Text view *
+ *************/
+
+textview text {
+  color: @text_color;
+  background-color: @base_color;
+}
+
 /*******************
 * Symbolic images *
 *******************/

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -434,7 +434,8 @@ entry.flat,
  * Text view *
  *************/
 
-textview, textview text {
+textview,
+textview text {
     color: @text_color;
     background-color: @base_color;
 }

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -434,7 +434,7 @@ entry.flat,
  * Text view *
  *************/
 
-textview text {
+textview, textview text {
     color: @text_color;
     background-color: @base_color;
 }


### PR DESCRIPTION
By some unknown reason GtkTextView background is not defined anywhere. See #249.
Even CSS editor in GtkDebugger (by Ctrl+Shift+D) is affected.

There is only least change, necessary to just make it working. Looking to Minwaita as example, you may find much more detailed definitions, such as for various text styles. I did not change gtk-3.0 because can't test for gtk+ <= gtk-3.20 (gentoo portage tree has removed everything lower then 3.22).