### PR TITLE
Scrollbar enhancement

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1753,11 +1753,11 @@ scrollbar.vertical slider {
     min-width: 3px;
 }
 
-scrollbar.overlay-indicator.horizontal:hover slider {
+scrollbar.horizontal:hover slider {
     min-height: 8px;
 }
 
-scrollbar.overlay-indicator.vertical:hover slider {
+scrollbar.vertical:hover slider {
     min-width: 8px;
 }
 

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1816,7 +1816,7 @@ scrollbar.overlay-indicator:hover trough {
 
 * > junction {
     border-style: none;
-    background-color: alpha (#000,0.10);
+    background-color: alpha (#000, 0.1);
 }
 
 /********

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -21,7 +21,6 @@
     -GtkTextView-error-underline-color: @error_color;
     -GtkIMHtml-hyperlink-color: @link_color;
     -GtkHTML-link-color: @link_color;
-    -GtkScrolledWindow-scrollbar-spacing: 0;
 
     /* -gtk-icon-palette: needs-attention @attention_color, success @success_color, warning @warning_color, error @error_color; FIXME: Uncomment for 3.19 */
 }
@@ -1799,6 +1798,10 @@ scrollbar.overlay-indicator:hover trough {
 scrolledwindow junction {
     border-style: none;
     background-color: @bg_color;
+}
+
+scrolledwindow {
+    -GtkScrolledWindow-scrollbar-spacing: 0;
 }
 
 /********

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1749,13 +1749,13 @@ scrollbar.horizontal slider {
     min-height: 3px;
 }
 
-scrollbar.horizontal:hover slider {
-    min-height: 8px;
-}
-
 scrollbar.vertical slider {
     min-height: 30px;
     min-width: 3px;
+}
+
+scrollbar.horizontal:hover slider {
+    min-height: 8px;
 }
 
 scrollbar.vertical:hover slider {

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1772,10 +1772,21 @@ scrollbar.overlay-indicator slider:hover {
     border-radius: 20px;
 }
 
-scrollbar.bottom trough { border-top-width: 1px; }
-scrollbar.top trough { border-bottom-width: 1px; }
-scrollbar.left trough { border-right-width: 1px; }
-scrollbar.right trough { border-left-width: 1px; }
+scrollbar.bottom trough {
+    border-top-width: 1px;
+}
+
+scrollbar.top trough {
+    border-bottom-width: 1px;
+}
+
+scrollbar.left trough {
+    border-right-width: 1px;
+}
+
+scrollbar.right trough {
+    border-left-width: 1px;
+}
 
 scrollbar trough {
     padding: 0;
@@ -1803,12 +1814,9 @@ scrollbar.overlay-indicator:hover trough {
     border-style: solid;
 }
 
-placessidebar > junction,
-placessidebar.frame > junction,
-scrolledwindow > junction,
-scrolledwindow.frame > junction {
-        border-style: none;
-        background-color: rgba (0,0,0,0.10);
+* > junction {
+    border-style: none;
+    background-color: alpha (#000,0.10);
 }
 
 /********

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1796,7 +1796,7 @@ scrollbar.overlay-indicator:hover trough {
 /* FIXME: background is ok, but nothing seems affecting junction border.
  * Even placing this block at the end of file doesn't help.
  * Can't find source, unless inspector will show junction node */
-scrolledwindow > junction, {
+scrolledwindow junction {
     border-style: none;
     background-color: @bg_color;
 }

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1772,8 +1772,15 @@ scrollbar.overlay-indicator slider:hover {
     border-radius: 20px;
 }
 
+scrollbar.bottom trough { border-top-width: 1px; }
+scrollbar.top trough { border-bottom-width: 1px; }
+scrollbar.left trough { border-right-width: 1px; }
+scrollbar.right trough { border-left-width: 1px; }
+
 scrollbar trough {
     padding: 0;
+    border-style: solid;
+    border-color: alpha (#000, 0.05);
 }
 
 trough {
@@ -1787,10 +1794,13 @@ scrollbar:hover trough {
 
 scrollbar.overlay-indicator trough {
     background-color: transparent;
+    border-style: none;
+    border-color: alpha (#000, 0.15);
 }
 
 scrollbar.overlay-indicator:hover trough {
     background-color: alpha (#000, 0.1);
+    border-style: solid;
 }
 
 placessidebar > junction,

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1772,26 +1772,8 @@ scrollbar.overlay-indicator slider:hover {
     border-radius: 20px;
 }
 
-scrollbar.bottom trough {
-    border-top-width: 1px;
-}
-
-scrollbar.top trough {
-    border-bottom-width: 1px;
-}
-
-scrollbar.left trough {
-    border-right-width: 1px;
-}
-
-scrollbar.right trough {
-    border-left-width: 1px;
-}
-
 scrollbar trough {
     padding: 0;
-    border-style: solid;
-    border-color: alpha (#000, 0.05);
 }
 
 trough {
@@ -1805,18 +1787,18 @@ scrollbar:hover trough {
 
 scrollbar.overlay-indicator trough {
     background-color: transparent;
-    border-style: none;
-    border-color: alpha (#000, 0.15);
 }
 
 scrollbar.overlay-indicator:hover trough {
     background-color: alpha (#000, 0.1);
-    border-style: solid;
 }
 
-* > junction {
+/* FIXME: background is ok, but nothing seems affecting junction border.
+ * Even placing this block at the end of file doesn't help.
+ * Can't find source, unless inspector will show junction node */
+scrolledwindow > junction, {
     border-style: none;
-    background-color: alpha (#000, 0.1);
+    background-color: @bg_color;
 }
 
 /********

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -21,6 +21,7 @@
     -GtkTextView-error-underline-color: @error_color;
     -GtkIMHtml-hyperlink-color: @link_color;
     -GtkHTML-link-color: @link_color;
+    -GtkScrolledWindow-scrollbar-spacing: 0;
 
     /* -gtk-icon-palette: needs-attention @attention_color, success @success_color, warning @warning_color, error @error_color; FIXME: Uncomment for 3.19 */
 }

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1754,11 +1754,11 @@ scrollbar.vertical slider {
     min-width: 3px;
 }
 
-scrollbar.horizontal:hover slider {
+scrollbar.overlay-indicator.horizontal:hover slider {
     min-height: 8px;
 }
 
-scrollbar.vertical:hover slider {
+scrollbar.overlay-indicator.vertical:hover slider {
     min-width: 8px;
 }
 

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1793,6 +1793,14 @@ trough {
     background-color: @base_color;
 }
 
+placessidebar > junction,
+placessidebar.frame > junction,
+scrolledwindow > junction,
+scrolledwindow.frame > junction {
+        border-style: none;
+        background-color: rgba (0,0,0,0.10);
+}
+
 /********
 * Menus *
 ********/

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1776,12 +1776,8 @@ scrollbar trough {
     padding: 0;
 }
 
-scrollbar.overlay-indicator trough {
-    background-color: transparent;
-}
-
-scrollbar.overlay-indicator:hover trough {
-    background-color: alpha (#000, 0.1);
+trough {
+    background-color: @base_color;
 }
 
 scrollbar:hover trough {
@@ -1789,8 +1785,12 @@ scrollbar:hover trough {
     border-radius: 0;
 }
 
-trough {
-    background-color: @base_color;
+scrollbar.overlay-indicator trough {
+    background-color: transparent;
+}
+
+scrollbar.overlay-indicator:hover trough {
+    background-color: alpha (#000, 0.1);
 }
 
 placessidebar > junction,


### PR DESCRIPTION
I made a set of scrollbar enhancement , which appeared to be hard to propose as separate pull requests  (most are too elementary, and it would be too long).
1. Static (non-overlay) scrollbars had artifact in scrollwindow junction, which becomes even more ugly, when scrollbars enlarge on hover.
![scrollbar-junction-before](https://user-images.githubusercontent.com/3896190/37800560-0319554a-2e45-11e8-9376-04a1d5d641ca.png)
the solution was to replace it with opaque rectangle, which is tiny bit darker, than trough at hovered scrollbar.
2. Static scrollbars in scrolled window had thick 3px border, which was controlled by some hidden setting, which doesn't appear in inspector (however, it may be found in adwaita's gtk-contained.css). Instead, static scrollbars now have light 1px border.
3. Overlay scrollbar trough also got hardening internal border - just an eye candy, for better contrast. Still enough light to perceive scrollbar as content addon.

Screenshots with new static and overlay scrollbars. For static scrollbars don't forget PR #294 :)
![nooverlay-scrollbars-new](https://user-images.githubusercontent.com/3896190/37800998-b43881ce-2e46-11e8-8ec8-3ad5e6a86c76.png) ![overlay-scrollbars-border](https://user-images.githubusercontent.com/3896190/37801009-bad94a36-2e46-11e8-971c-2586da37484b.png)

p.s. Should not static scrollbars be a bit thicker, e.g. 5px?