### PR TITLE
Better scale accuracy

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -739,7 +739,7 @@ scale slider {
         inset 0 -1px 0 0 alpha (#fff, 0.15),
         0 0 0 1px alpha (#000, 0.25),
         0 1px 1px 1px alpha (#000, 0.1);
-    margin: -7px 0;
+    margin: -7px;
     min-height: 14px;
     min-width: 14px;
 }
@@ -813,10 +813,6 @@ scale trough {
 
 .titlebar scale trough {
     border-radius: 0 12px 12px 0;
-}
-
-scale.vertical slider {
-    margin: 0 -7px;
 }
 
 scale.vertical trough {


### PR DESCRIPTION
There was noticeable offset from cursor to scale slider when changing value. It was most visible when interacting with Granite SeekBar.

All sides of slider now have margin, similar to Adwaita theme.

this fixes https://github.com/elementary/videos/issues/103