### PR TITLE
Force titlebuttons symbolic

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -3747,6 +3747,10 @@ messagedialog .titlebar.default-decoration:backdrop {
     box-shadow: none;
 }
 
+.titlebar .titlebutton image {
+    -gtk-icon-style: symbolic;
+}
+
 .titlebar .title:disabled,
 .titlebar .subtitle:disabled,
 .titlebar .titlebutton:disabled,


### PR DESCRIPTION
Fixes #289 

Looks like for some reason Gtk.MessageDialog was not using the symbolic icon variant. Forcing titlebuttons to be symbolic fixes this