### PR TITLE
Dark palette in entries

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -396,6 +396,7 @@ toolbar spinbutton:disabled:backdrop,
 entry image {
     color: @internal_element_color;
     transition: all 200ms ease-in-out;
+    -gtk-icon-palette: needs-attention @attention_color, success @LIME_500, warning @BANANA_500, error @error_color;
 }
 
 entry image:backdrop {


### PR DESCRIPTION
Make sure that icons in entries have high contrast

## Before

![screenshot from 2018-05-08 18 01 09 2x](https://user-images.githubusercontent.com/7277719/39790260-e0512c4e-52e9-11e8-9da9-c42e483c388b.png)


## After

![screenshot from 2018-05-08 18 00 44 2x](https://user-images.githubusercontent.com/7277719/39790263-e33c5578-52e9-11e8-8670-0f3bb423601e.png)


