### PR TITLE
Add an inline toolbar style for tabs

### DIFF
--- a/gtk-3.22/gtk-dark.css
+++ b/gtk-3.22/gtk-dark.css
@@ -91,7 +91,6 @@
 @define-color colorAccent @selected_bg_color;
 @define-color textColorPrimary shade (@text_color, 0.9);
 @define-color textColorPrimaryShadow alpha (shade (@colorPrimary, 0.5), 0.6);
-
 @define-color tab_base_color @base_color;
 
 /* Default color scheme */

--- a/gtk-3.22/gtk-dark.css
+++ b/gtk-3.22/gtk-dark.css
@@ -92,6 +92,8 @@
 @define-color textColorPrimary shade (@text_color, 0.9);
 @define-color textColorPrimaryShadow alpha (shade (@colorPrimary, 0.5), 0.6);
 
+@define-color tab_base_color @base_color;
+
 /* Default color scheme */
 @define-color base_color #3d4248;
 @define-color bg_color shade (@base_color, 0.96);

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1736,6 +1736,41 @@ notebook tab label:backdrop {
     color: alpha(@text_color, 0.75);
 }
 
+.inline-toolbar notebook header {
+    background-color: shade (@tab_base_color, 0.95);
+    background-image:
+        linear-gradient(
+            to bottom,
+            alpha (
+                #000,
+                0.12
+            ),
+            alpha (
+                #000,
+                0
+            ) 2px,
+            alpha (
+                #000,
+                0
+            ) calc(100% - 1px),
+            alpha (
+                #000,
+                0.05
+            ) 
+        );
+    border-color: shade (@tab_base_color, 0.78);
+}
+
+.inline-toolbar notebook tab:checked {
+    background-color: @tab_base_color;
+    background-image: none;
+    border-color: shade (@tab_base_color, 0.78);
+    box-shadow:
+        -1px 0 1px alpha (#000, 0.05),
+        1px 0 1px alpha (#000, 0.05);
+    margin-bottom: -1px;
+}
+
 /*************
 * Scrollbars *
 *************/

--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -1756,7 +1756,7 @@ notebook tab label:backdrop {
             alpha (
                 #000,
                 0.05
-            ) 
+            )
         );
     border-color: shade (@tab_base_color, 0.78);
 }

--- a/gtk-3.22/gtk.css
+++ b/gtk-3.22/gtk.css
@@ -91,7 +91,6 @@
 @define-color colorAccent @selected_bg_color;
 @define-color textColorPrimary mix (@colorPrimary, @text_color, 0.75);
 @define-color textColorPrimaryShadow alpha (shade (@colorPrimary, 1.4), 0.4);
-
 @define-color tab_base_color @base_color;
 
 /* Default color scheme */

--- a/gtk-3.22/gtk.css
+++ b/gtk-3.22/gtk.css
@@ -92,6 +92,8 @@
 @define-color textColorPrimary mix (@colorPrimary, @text_color, 0.75);
 @define-color textColorPrimaryShadow alpha (shade (@colorPrimary, 1.4), 0.4);
 
+@define-color tab_base_color @base_color;
+
 /* Default color scheme */
 @define-color base_color white;
 @define-color bg_color shade (@base_color, 0.96);


### PR DESCRIPTION
Adds a style for tabs that can be used with the `inline-toolbar` class and a color variable so you can manually set the color here.

Feedback wanted on the color variable name

![screenshot from 2018-05-09 12 16 34 2x](https://user-images.githubusercontent.com/7277719/39834789-ec61cea0-5382-11e8-893e-cb0710bf52b7.png)
![screenshot from 2018-05-09 12 16 49 2x](https://user-images.githubusercontent.com/7277719/39834790-ec960f94-5382-11e8-9beb-035e81dcf788.png)
