### PR TITLE
Fix text background and color in fake terminal style

### DIFF
--- a/gtk-3.22/granite-widgets.css
+++ b/gtk-3.22/granite-widgets.css
@@ -643,7 +643,8 @@ scale trough:disabled {
 * Fake Terminal *
 ****************/
 
-.terminal {
+.terminal,
+.terminal text {
     background-color: #252e32;
     color: #94a3a5;
     font-family: monospace;


### PR DESCRIPTION
Fixes a regression with the fake terminal style as seen in Granite demo