### PR TITLE
Fix titlebar flat button radius

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -2317,7 +2317,7 @@ toolbar.bottom-toolbar button,
 .titlebar button.image-button,
 .titlebar .button.flat,
 .titlebar .button.image-button {
-    border-radius: 50%;
+    border-radius: 99px;
     background-color: transparent;
 }
 


### PR DESCRIPTION
We never want this to be an ellipse, so use a large border radius instead:

## BEFORE

![screenshot from 2018-05-29 10 23 01 2x](https://user-images.githubusercontent.com/7277719/40674682-66fcebb6-632a-11e8-99bb-f4bf38daa7dd.png)

## AFTER

![screenshot from 2018-05-29 10 22 13 2x](https://user-images.githubusercontent.com/7277719/40674690-6a55b900-632a-11e8-88d6-276f8e2033bb.png)
