### PR TITLE
Style box inside the infobar revealer

### DIFF
--- a/gtk-3.22/gtk-widgets.css
+++ b/gtk-3.22/gtk-widgets.css
@@ -3435,7 +3435,7 @@ calendar .view {
 * GtkInfoBar *
 *************/
 
-infobar {
+infobar revealer > box {
     background-color: @bg_color;
     background-image: -gtk-icontheme("dialog-information-symbolic");
     background-size: 16px;
@@ -3450,19 +3450,9 @@ infobar {
     padding-left: 24px;
 }
 
-infobar:dir(rtl) {
+infobar:dir(rtl) revealer > box {
     background-position: calc(100% - 9px) center;
     padding-right: 24px;
-}
-
-infobar.frame {
-    border-radius: 3px;
-    box-shadow:
-        inset 0 0 0 1px alpha (#fff, 0.05),
-        inset 0 1px 0 0 alpha (#fff, 0.45),
-        inset 0 -1px 0 0 alpha (#fff, 0.15),
-        0 1px 1px alpha (#000, 0.03),
-        0 1px 2px alpha (#000, 0.1);
 }
 
 infobar label {
@@ -3470,7 +3460,7 @@ infobar label {
     padding: 3px;
 }
 
-infobar.error {
+infobar.error revealer > box {
     background-color: shade (@error_color, 1.2);
     background-image: -gtk-icontheme("process-error-symbolic");
     border-color: @error_color;
@@ -3486,7 +3476,7 @@ infobar.error label {
     text-shadow: 0 1px 1px @error_color;
 }
 
-infobar.question {
+infobar.question revealer > box {
     background-color: shade (@selected_bg_color, 1.2);
     background-image: -gtk-icontheme("dialog-question-symbolic");
     border-color: shade (@selected_bg_color, 0.9);
@@ -3500,7 +3490,7 @@ infobar.question label {
     color: shade (@selected_bg_color, 0.25);
 }
 
-infobar.warning {
+infobar.warning revealer > box {
     background-color: shade (@warning_color, 1.2);
     background-image: -gtk-icontheme("dialog-warning-symbolic");
     border-color: shade (@warning_color, 0.9);
@@ -3521,6 +3511,22 @@ infobar.warning button:backdrop {
 
 infobar.warning label {
     color: shade (@warning_color, 0.25);
+}
+
+infobar.frame {
+    border: none;
+}
+
+infobar.frame revealer > box {
+    border-width: 1px;
+    border-radius: 3px;
+    box-shadow:
+        inset 0 0 0 1px alpha (#fff, 0.05),
+        inset 0 1px 0 0 alpha (#fff, 0.45),
+        inset 0 -1px 0 0 alpha (#fff, 0.15),
+        0 1px 1px alpha (#000, 0.03),
+        0 1px 2px alpha (#000, 0.1);
+    margin: 3px;
 }
 
 infobar entry,


### PR DESCRIPTION
Instead of styling the infobar itself, style the box inside the revealer

Turns out these days infobar has a revealer packed in. By styling the revealer itself, borders are still drawn when the revealer is "closed". By styling the box inside the revealer, borders will be hidden.

Should save on adding revealers for infobars since we can just use the built-in revealed property

Handy infobar reference is either switchboard power plug or gtk3-demo