### PR TITLE
Remove unused dark spinbutton rules

### DIFF
--- a/gtk-3.0/gtk-widgets-dark.css
+++ b/gtk-3.0/gtk-widgets-dark.css
@@ -241,26 +241,6 @@ switch:checked slider {
         inset 0 -1px 0 0 alpha (#fff, 0.4);
 }
 
-/*****************
- * GtkSpinButton *
- *****************/
-
-.spinbutton .button {
-    border-style: none;
-    border-image: none;
-    box-shadow: inset 1px 0 alpha (#000, 0.1);
-    background-color: transparent;
-    background-image: none;
-}
-
-.spinbutton .button:first-child {
-    box-shadow: none;
-}
-
-.spinbutton .button:dir(rtl) {
-    box-shadow: inset -1px 0 alpha (#000, 0.1);
-}
-
 /*********
 * Linked *
 *********/


### PR DESCRIPTION
These selectors are no longer valid and it seems that spinbuttons already look right in the dark stylesheet