### PR TITLE
Use mix instead of brighten for disabled titlebar button color

### DIFF
--- a/gtk-3.0/gtk-widgets.css
+++ b/gtk-3.0/gtk-widgets.css
@@ -3755,7 +3755,7 @@ messagedialog .titlebar.default-decoration:backdrop {
 .titlebar .subtitle:disabled,
 .titlebar .titlebutton:disabled,
 .titlebar *:not(entry) image:disabled {
-    color: shade (@textColorPrimary, 1.5);
+    color: mix (@textColorPrimary, @colorPrimary, 0.35);
     text-shadow: 0 1px @textColorPrimaryShadow;
     -gtk-icon-shadow: 0 1px @textColorPrimaryShadow;
 }


### PR DESCRIPTION
Fixes #97 

Uses a mix (between color and background color) instead of a shade (brighten) to create the insensitive color in titlebars.

Also works better with branded titlebars:

## BEFORE
![screenshot from 2018-08-08 11 22 42 2x](https://user-images.githubusercontent.com/7277719/43856459-72336b30-9afd-11e8-9a64-f81cc4323707.png)

## AFTER
![screenshot from 2018-08-08 11 22 56 2x](https://user-images.githubusercontent.com/7277719/43856460-726343d2-9afd-11e8-987a-30974a025865.png)
