### PR TITLE
Add Meson build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 *~
 /node_modules/
+build/

--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ If you feel the desire to compensate the designers who maintain this stylesheet 
 
 Special fixes for GNOME apps (Nautilus, GNOME Control Center, GNOME Shell, etc) or other desktop environments will not be implemented. The aim of style classes should be to be generic across applications. If an application needs a unique style,  it should be bundled with that application.
 
-## Testing
+## Installation & Testing
 
-This stylesheet doesn't need to be compiled. It is recommended to make a
-symbolic link from the source directory to "/usr/share/themes" for testing:
+Run `meson` to configure the build environment. To install, use `ninja install`.
 
-    ln -s /path/to/your/branch/elementary /usr/share/themes/
+    meson build --prefix=/usr
+    cd build
+    sudo ninja install
     
-Apps will need to be restarted or the system stylesheet will need to be
+Apps may need to be restarted or the system stylesheet will need to be
 changed for your changes to take effect.
 
 You can also test changes live with Gtk Inspector. Make sure you have Gtk

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,6 @@
+project('io.elementary.stylesheet')
+
+install_subdir(
+    'elementary',
+    install_dir: join_paths(get_option('datadir'), 'themes')
+)


### PR DESCRIPTION
Add a basic Meson build system to handle installation and update README to recommend installing with it.

This will come in handy if we move to a pre-processor and makes it so we don't need to rely on packaging to install files