### PR TITLE
Soften gradient on Gtk.TreeView headers so it looks good with inline tabs

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets-dark.css
+++ b/elementary/gtk-3.0/gtk-widgets-dark.css
@@ -684,40 +684,15 @@ GtkAssistant .sidebar {
  * Column Headers *
  *********************/
 column-header .button {
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @titlebar_color,
-                0.88
-            ),
-            @titlebar_color
-        );
-    border-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @titlebar_color,
-                0.88
-            ),
-            shade (
-                @titlebar_color,
-                0.7
-            )
-        ) 0 0 1 1;
+    background-image: none;
+    background-color: shade (@titlebar_color, 0.88);
+    border-color: shade (@titlebar_color, 0.88);
+    border-image: none;
     font-weight: bold;
 }
 
 column-header .button:hover {
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @titlebar_color,
-                0.8
-            ),
-            @titlebar_color
-        );
+    background-color: shade (@titlebar_color, 0.8);
 }
 
 /*************

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3055,10 +3055,7 @@ column-header .button {
                 @bg_color,
                 1.1
             ),
-            shade (
-                @bg_color,
-                1.0
-            )
+            @bg_color
         );
     font-weight: bold;
     padding: 4px 2px;

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3048,15 +3048,7 @@ column-header .button {
     border-top-width: 0;
     border-radius: 0;
     background-color: @bg_color;
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @base_color,
-                0.88
-            ),
-            @base_color
-        );
+    background-image: none;
     font-weight: bold;
     padding: 4px 2px;
 }
@@ -3068,15 +3060,7 @@ column-header:last-child .button {
 
 treeview header button:hover,
 column-header .button:hover {
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @base_color,
-                0.8
-            ),
-            @base_color
-        );
+    background-color: @base_color;
 }
 
 treeview header button:backdrop,
@@ -3086,15 +3070,7 @@ column-header .button:backdrop {
 
 treeview header button:backdrop:hover,
 column-header .button:backdrop:hover {
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @bg_color,
-                0.92
-            ),
-            @bg_color
-        );
+    background-color: @bg_color;
 }
 
 treeview header button label {

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3051,8 +3051,14 @@ column-header .button {
     background-image:
         linear-gradient(
             to bottom,
-            shade (@bg_color, 1.1),
-            shade (@bg_color, 1.0)
+            shade (
+                @bg_color,
+                1.1
+            ),
+            shade (
+                @bg_color,
+                1.0
+            )
         );
     font-weight: bold;
     padding: 4px 2px;

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3048,7 +3048,12 @@ column-header .button {
     border-top-width: 0;
     border-radius: 0;
     background-color: shade (@bg_color, 1.1);
-    background-image: none;
+    background-image:
+        linear-gradient(
+            to bottom,
+            shade (@bg_color, 1.1),
+            shade (@bg_color, 1.0)
+        );
     font-weight: bold;
     padding: 4px 2px;
 }

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3047,7 +3047,7 @@ column-header .button {
     border-left-width: 0;
     border-top-width: 0;
     border-radius: 0;
-    background-color: @bg_color;
+    background-color: shade (@bg_color, 1.1);
     background-image: none;
     font-weight: bold;
     padding: 4px 2px;
@@ -3060,7 +3060,7 @@ column-header:last-child .button {
 
 treeview header button:hover,
 column-header .button:hover {
-    background-color: @base_color;
+    background-color: @bg_color;
 }
 
 treeview header button:backdrop,


### PR DESCRIPTION
Makes it so the treeview column header widgets not clash with inline tabs, by removing the old gradient.
Also works with Dark theme.
Fixes #383.

Old:
![old-treeview-headers](https://user-images.githubusercontent.com/4886639/46262652-80588680-c4da-11e8-9f69-af2abcb3e7f7.png)

New:
![new-treeview-headers](https://user-images.githubusercontent.com/4886639/46262791-9f581800-c4dc-11e8-8012-f1ae8a762c90.png)