### PR TITLE
Make close button icon white in error-type Infobars

### DIFF
--- a/elementary/gtk-3.0/granite-widgets.css
+++ b/elementary/gtk-3.0/granite-widgets.css
@@ -612,7 +612,9 @@ window.rounded decoration {
 * Text Styles *
 **************/
 
-.accent {
+.accent,
+.titlebar.flat .accent image,
+.titlebar.flat .accent label {
     color: @colorAccent;
 }
 

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3560,7 +3560,7 @@ infobar.error revealer > box {
 }
 
 infobar.error label,
-infobar.error.close {
+infobar.error .close {
     color: #fff;
     text-shadow: 0 1px 1px @error_color;
 }

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3564,6 +3564,7 @@ infobar.error label,
 infobar.error .close {
     color: #fff;
     text-shadow: 0 1px 1px @error_color;
+    -gtk-icon-shadow: transparent;
 }
 
 infobar.question revealer > box {

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3572,7 +3572,7 @@ infobar.error label,
 infobar.error .close {
     color: #fff;
     text-shadow: 0 1px 1px @error_color;
-    -gtk-icon-shadow: transparent;
+    -gtk-icon-shadow: 0 1px 1px alpha (shade (@error_color, 1.4), 0.4);
 }
 
 infobar.question revealer > box {

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3572,7 +3572,7 @@ infobar.error label,
 infobar.error .close {
     color: #fff;
     text-shadow: 0 1px 1px @error_color;
-    -gtk-icon-shadow: 0 1px 1px alpha (shade (@error_color, 1.4), 0.4);
+    -gtk-icon-shadow: 0 1px 1px @error_color;
 }
 
 infobar.question revealer > box {

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2171,11 +2171,15 @@ radio {
     border-radius: 50%;
 }
 
+radiobutton image:dir(ltr),
+checkbutton image:dir(ltr),
 radiobutton label:dir(ltr),
 checkbutton label:dir(ltr) {
     margin-left: 6px;
 }
 
+radiobutton image:dir(rtl),
+checkbutton image:dir(rtl),
 radiobutton label:dir(rtl),
 checkbutton label:dir(rtl) {
     margin-right: 6px;

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3559,11 +3559,7 @@ infobar.error revealer > box {
     -gtk-icon-palette: error #fff;
 }
 
-infobar.error label {
-    color: #fff;
-    text-shadow: 0 1px 1px @error_color;
-}
-
+infobar.error label,
 infobar.error.close {
     color: #fff;
     text-shadow: 0 1px 1px @error_color;

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3564,6 +3564,11 @@ infobar.error label {
     text-shadow: 0 1px 1px @error_color;
 }
 
+infobar.error.close {
+    color: #fff;
+    text-shadow: 0 1px 1px @error_color;
+}
+
 infobar.question revealer > box {
     background-color: shade (@selected_bg_color, 1.2);
     background-image: -gtk-icontheme("dialog-question-symbolic");


### PR DESCRIPTION
When using the error class in infobars, makes the close button white instead of dark.
Fixes #380.

Looks like this:
Old =
![old-error](https://user-images.githubusercontent.com/4886639/46269724-4d81b300-c519-11e8-8832-70cdb3107740.png)

New =
![new-error](https://user-images.githubusercontent.com/4886639/46269729-51add080-c519-11e8-94e7-142d3afc866c.png)
