### PR TITLE
Remove background color from disabled Gtk.Button in dark stylesheet

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets-dark.css
+++ b/elementary/gtk-3.0/gtk-widgets-dark.css
@@ -172,6 +172,16 @@ button:active:disabled,
         0 1px 0 1px alpha (#fff, 0.3);
 }
 
+button.destructive-action:disabled,
+.button.destructive-action:disabled {
+    background-image: none;
+    background-color: transparent;
+    color: alpha (@fg_color, 0.88);
+    box-shadow:
+        inset 0 0 0 1px alpha (#000, 0.05),
+        0 1px 0 1px alpha (#fff, 0.3);
+}
+
 /****************************
  * Check, Radio, and Switch *
  ***************************/

--- a/elementary/gtk-3.0/gtk-widgets-dark.css
+++ b/elementary/gtk-3.0/gtk-widgets-dark.css
@@ -172,16 +172,6 @@ button:active:disabled,
         0 1px 0 1px alpha (#fff, 0.3);
 }
 
-button.destructive-action:disabled,
-.button.destructive-action:disabled {
-    background-image: none;
-    background-color: transparent;
-    color: alpha (@fg_color, 0.88);
-    box-shadow:
-        inset 0 0 0 1px alpha (#000, 0.05),
-        0 1px 0 1px alpha (#fff, 0.3);
-}
-
 /****************************
  * Check, Radio, and Switch *
  ***************************/
@@ -636,10 +626,15 @@ button.destructive-action:focus,
 **********************/
 
 .button:disabled,
-.suggested-action.button:disabled {
+.text-button:disabled,
+.suggested-action.button:disabled,
+.destructive-action.button:disabled,
+.suggested-action.text-button:disabled,
+.destructive-action.text-button:disabled {
     background-image: none;
     background-color: transparent;
     border-color: alpha (#000, 0.2);
+    box-shadow: none;
 }
 
 .toolbar .button:disabled {


### PR DESCRIPTION
Makes the destructive-styled button when disabled have no background color in the dark stylesheet.
Fixes #364.

Looks like this:
Old =
![screenshot from 2018-10-01 01 39 54](https://user-images.githubusercontent.com/4886639/46270454-ff22e300-c51d-11e8-9024-26095edce828.png)

New =
![screenshot from 2018-10-01 02-02-23](https://user-images.githubusercontent.com/4886639/46270484-1c57b180-c51e-11e8-8d51-86f6dd27866c.png)