### PR TITLE
Fix menuitem color from suggested-action buttons

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2616,14 +2616,9 @@ button.suggested-action,
         0 1px 0 0 alpha (#fff, 0.15);
 }
 
-button.suggested-action:not(:disabled) label,
-button.suggested-action:not(:disabled) label:hover,
-button.suggested-action:not(:disabled) image,
-button.suggested-action:not(:disabled) image:hover,
+button.suggested-action:not(:disabled),
 .titlebar button.suggested-action:not(:disabled) label,
-.titlebar button.suggested-action:not(:disabled) label:hover,
-.titlebar button.suggested-action:not(:disabled) image,
-.titlebar button.suggested-action:not(:disabled) image:hover {
+.titlebar button.suggested-action:not(:disabled) image {
     color: @selected_fg_color;
     text-shadow: 0 1px alpha (#000, 0.3);
     -gtk-icon-shadow: 0 1px alpha (#000, 0.3);

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2617,8 +2617,8 @@ button.suggested-action,
 }
 
 button.suggested-action:not(:disabled),
-.titlebar button.suggested-action:not(:disabled) label,
-.titlebar button.suggested-action:not(:disabled) image {
+.titlebar button.suggested-action:not(:disabled) > label,
+.titlebar button.suggested-action:not(:disabled) > image {
     color: @selected_fg_color;
     text-shadow: 0 1px alpha (#000, 0.3);
     -gtk-icon-shadow: 0 1px alpha (#000, 0.3);


### PR DESCRIPTION
These selectors may have needed to be this specific in an older version of the stylesheet, but I don't see why they need to be anymore. Tested this with suggested action buttons in headers in dark and light with brand colors.

## BEFORE
![screenshot from 2018-10-01 15 01 02 2x](https://user-images.githubusercontent.com/7277719/46319091-9d01c680-c58d-11e8-864e-02cc6883fcc2.png)

## AFTER
![screenshot from 2018-10-01 15 15 15 2x](https://user-images.githubusercontent.com/7277719/46319092-9d01c680-c58d-11e8-9960-fac2518efaa5.png)
