### PR TITLE
Unblur the icon used to show Infobar Type

### DIFF
--- a/elementary/gtk-3.0/granite-widgets.css
+++ b/elementary/gtk-3.0/granite-widgets.css
@@ -612,7 +612,9 @@ window.rounded decoration {
 * Text Styles *
 **************/
 
-.accent {
+.accent,
+.titlebar.flat .accent image,
+.titlebar.flat .accent label {
     color: @colorAccent;
 }
 

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3537,7 +3537,7 @@ infobar revealer > box {
     background-image: -gtk-icontheme("dialog-information-symbolic");
     background-size: 16px;
     background-repeat: no-repeat;
-    background-position: 9px 12px;
+    background-position: 9px 1em;
     border-color: shade (@bg_color, 0.8);
     border-style: solid;
     border-width: 0 0 1px;

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -1083,6 +1083,14 @@ button.link:focus > label {
     text-decoration: underline;
 }
 
+button.file {
+    padding: 3px;
+}
+
+button.file label {
+    padding: 0;
+}
+
 /***************************
 * Overlay Button *
 ***************************/
@@ -1916,7 +1924,8 @@ modelbutton *:disabled,
     color: @insensitive_color;
 }
 
-menuitem accelerator {
+menuitem accelerator,
+.accelerator {
     color: alpha (@text_color, 0.5);
 }
 
@@ -3528,7 +3537,7 @@ infobar revealer > box {
     background-image: -gtk-icontheme("dialog-information-symbolic");
     background-size: 16px;
     background-repeat: no-repeat;
-    background-position: 9px center;
+    background-position: 9px 12px;
     border-color: shade (@bg_color, 0.8);
     border-style: solid;
     border-width: 0 0 1px;
@@ -3559,9 +3568,11 @@ infobar.error revealer > box {
     -gtk-icon-palette: error #fff;
 }
 
-infobar.error label {
+infobar.error label,
+infobar.error .close {
     color: #fff;
     text-shadow: 0 1px 1px @error_color;
+    -gtk-icon-shadow: 0 1px 1px alpha (shade (@error_color, 1.4), 0.4);
 }
 
 infobar.question revealer > box {
@@ -4282,4 +4293,3 @@ overshoot.left {
             alpha(@colorAccent, 0.075) 100%
         );
 }
-


### PR DESCRIPTION
This makes it so the icon doesn't land in a half-pixel, making it not blur.

Looks like this:
Old =
![screenshot from 2018-10-01 19-43-24](https://user-images.githubusercontent.com/4886639/46319981-9b96c500-c5b2-11e8-948d-d8a6562aa5b6.png)

New =
![screenshot from 2018-10-01 19-43-55](https://user-images.githubusercontent.com/4886639/46319986-a3ef0000-c5b2-11e8-872a-cbc6bffb9dbb.png)

