### PR TITLE
Fix notebook background

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -1536,16 +1536,16 @@ combobox button:last-child:not(:only-child) {
 ********************/
 
 notebook {
-    background-clip: border-box;
-    background-color: shade (@titlebar_color, 1.06);
     border: none;
-    border-radius: 0 0 2.5px 2.5px;
     text-shadow: 0 1px @text_shadow_color;
     -gtk-icon-shadow: 0 1px @text_shadow_color;
 }
 
 notebook.frame {
     border: 1px solid shade (@titlebar_color, 0.6);
+    border-radius: 0 0 2.5px 2.5px;
+    background-color: shade (@titlebar_color, 1.06);
+    background-clip: border-box;
 }
 
 notebook header {


### PR DESCRIPTION
Make background to be visible for notebook background
and don't appear for frameless notebooks.
_________________

Current situation is that background fill occurs for frameless notebooks, but doesn't happen for notebook with frame. This problem is not elementary-specific, yet i don't have installed any elementary app with tabs (those, i have, prefer isolated tabbar looking like button box, more suitable for headerbar).

There is difference showcase below, with gtk3 apps using tabs, i could arrange on desktop to keep visible.

After:
![elementary-notebook-after](https://user-images.githubusercontent.com/3896190/47645487-024bd600-db93-11e8-85a8-68f133f805a9.png)

Before:
![elementary-notebook-before](https://user-images.githubusercontent.com/3896190/47645503-0972e400-db93-11e8-8fec-4403ddcb8e88.png)

note: ugly notebook look in tabs now got fix to upstream, but it obviously should not draw background without frame too.