### PR TITLE
Support directly-styled titlebar images and labels

### DIFF
--- a/elementary/gtk-3.0/granite-widgets.css
+++ b/elementary/gtk-3.0/granite-widgets.css
@@ -615,6 +615,8 @@ window.rounded decoration {
 **************/
 
 .accent,
+.titlebar label.accent,
+.titlebar image.accent,
 .titlebar.flat .accent image,
 .titlebar.flat .accent label {
     color: @colorAccent;


### PR DESCRIPTION
So we can support #445 in headerbars