### PR TITLE
Always use light switch sliders

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2208,13 +2208,14 @@ switch slider {
             shade(@SILVER_100, 1.05),
             shade(@SILVER_100, 0.95)
         );
+    border: 1px solid alpha(#000, 0.2);
     border-radius: 50%;
     box-shadow:
         inset 0 0 0 1px alpha(#fff, 0.05),
         inset 0 1px 0 0 alpha(#fff, 0.45),
         inset 0 -1px 0 0 alpha(#fff, 0.15),
-        0 0 0 1px alpha(#000, 0.25),
-        0 1px 1px 1px alpha(#000, 0.1);
+        0 1px 1px alpha(#000, 0.15),
+        0 1px 2px alpha(#000, 0.16);
     margin: -1px;
     min-height: 24px;
     min-width: 24px;

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -1544,16 +1544,16 @@ combobox button:last-child:not(:only-child) {
 ********************/
 
 notebook {
-    background-clip: border-box;
-    background-color: shade (@titlebar_color, 1.06);
     border: none;
-    border-radius: 0 0 2.5px 2.5px;
     text-shadow: 0 1px @text_shadow_color;
     -gtk-icon-shadow: 0 1px @text_shadow_color;
 }
 
 notebook.frame {
     border: 1px solid shade (@titlebar_color, 0.6);
+    border-radius: 0 0 2.5px 2.5px;
+    background-color: shade (@titlebar_color, 1.06);
+    background-clip: border-box;
 }
 
 notebook header {

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2059,26 +2059,17 @@ switch:focus slider {
     background-image:
         linear-gradient(
             to bottom,
-            shade (
-                @bg_color,
-                1.05
-            ),
-            shade (
-                mix (
-                    @bg_color,
-                    @colorAccent,
-                    0.1
-                ),
-                0.95
-            )
+            shade(@SILVER_100, 1.05),
+            shade(mix(@SILVER_100, @colorAccent, 0.1), 0.95)
         );
     border-color: @colorAccent;
     box-shadow:
-        inset 0 0 0 1px alpha (@bg_highlight_color, 0.05),
-        inset 0 1px 0 0 alpha (@bg_highlight_color, 0.45),
-        inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.15),
-        0 1px 1px alpha (@colorAccent, 0.35),
-        0 1px 2px alpha (@colorAccent, 0.16);
+        inset 0 0 0 1px alpha(#fff, 0.05),
+        inset 0 1px 0 0 alpha(#fff, 0.45),
+        inset 0 -1px 0 0 alpha(#fff, 0.15),
+        0 0 0 1px alpha(shade(@colorAccent, 0.5), 0.25),
+        0 1px 1px alpha(@colorAccent, 0.35),
+        0 1px 2px alpha(@colorAccent, 0.16);
 }
 
 switch:checked {
@@ -2206,17 +2197,16 @@ switch slider {
     background-image:
         linear-gradient(
             to bottom,
-            shade(@SILVER_100, 1.1),
-            shade(@SILVER_100, 0.9)
+            shade(@SILVER_100, 1.05),
+            shade(@SILVER_100, 0.95)
         );
-    border: 1px solid alpha(#000, 0.2);
     border-radius: 50%;
     box-shadow:
-        inset 0 0 0 1px alpha(white, 0.05),
-        inset 0 1px 0 0 alpha(white, 0.45),
-        inset 0 -1px 0 0 alpha(white, 0.15),
-        0 1px 1px alpha(#000, 0.15),
-        0 1px 2px alpha(#000, 0.16);
+        inset 0 0 0 1px alpha(#fff, 0.05),
+        inset 0 1px 0 0 alpha(#fff, 0.45),
+        inset 0 -1px 0 0 alpha(#fff, 0.15),
+        0 0 0 1px alpha(#000, 0.25),
+        0 1px 1px 1px alpha(#000, 0.1);
     margin: -1px;
     min-height: 24px;
     min-width: 24px;

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2206,23 +2206,17 @@ switch slider {
     background-image:
         linear-gradient(
             to bottom,
-            shade (
-                @bg_color,
-                1.05
-            ),
-            shade (
-                @bg_color,
-                0.95
-            )
+            shade(@SILVER_100, 1.1),
+            shade(@SILVER_100, 0.9)
         );
-    border: 1px solid alpha (#000, 0.2);
+    border: 1px solid alpha(#000, 0.2);
     border-radius: 50%;
     box-shadow:
-        inset 0 0 0 1px alpha (@bg_highlight_color, 0.05),
-        inset 0 1px 0 0 alpha (@bg_highlight_color, 0.45),
-        inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.15),
-        0 1px 1px alpha (#000, 0.15),
-        0 1px 2px alpha (#000, 0.16);
+        inset 0 0 0 1px alpha(white, 0.05),
+        inset 0 1px 0 0 alpha(white, 0.45),
+        inset 0 -1px 0 0 alpha(white, 0.15),
+        0 1px 1px alpha(#000, 0.15),
+        0 1px 2px alpha(#000, 0.16);
     margin: -1px;
     min-height: 24px;
     min-width: 24px;

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2075,7 +2075,6 @@ switch:focus slider {
         inset 0 0 0 1px alpha(#fff, 0.05),
         inset 0 1px 0 0 alpha(#fff, 0.45),
         inset 0 -1px 0 0 alpha(#fff, 0.15),
-        0 0 0 1px alpha(shade(@colorAccent, 0.5), 0.25),
         0 1px 1px alpha(@colorAccent, 0.35),
         0 1px 2px alpha(@colorAccent, 0.16);
 }
@@ -2090,7 +2089,7 @@ switch:checked {
             ),
             @colorAccent
         );
-    border-color: shade (@colorAccent, 0.85);
+    border-color: shade(@colorAccent, 0.85);
 }
 
 check:checked,


### PR DESCRIPTION
This translates the light style sliders over to the dark style, much like we did for scales. This makes them a lot easier to spot and higher contrast.

| Before | After |
|-----|-----|
| ![screenshot from 2018-11-20 15 03 21](https://user-images.githubusercontent.com/611168/48805751-716da380-ecd5-11e8-9f82-c8b98cbd5035.png) | ![screenshot from 2018-11-20 15 30 24](https://user-images.githubusercontent.com/611168/48806967-4b4a0280-ecd9-11e8-8505-8142dd0e0c3f.png) |
| ![screenshot from 2018-11-20 15 03 16](https://user-images.githubusercontent.com/611168/48805759-76caee00-ecd5-11e8-802f-3195f8579c6f.png) | ![screenshot from 2018-11-20 15 30 19](https://user-images.githubusercontent.com/611168/48806956-4422f480-ecd9-11e8-8196-2445f5feadb6.png) |