### PR TITLE
Remove the rounded edges of tabs

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -1676,7 +1676,7 @@ notebook tab:checked {
         );
     border-color: shade (@titlebar_color, 0.62);
     border-image: none;
-    border-radius: 4px 4px 0 0;
+    border-radius: 0;
     border-style: solid;
     box-shadow:
         inset 0 0 0 1px alpha (@bg_highlight_color, 0.2),


### PR DESCRIPTION
I would like to make this a proposal for removing the rounded edges for the tabs. Have a look at the current style of the tabs in the Terminal application.
![screenshot from 2018-12-02 11 34 30](https://user-images.githubusercontent.com/437678/49338749-8aa41780-f626-11e8-905f-f8f55a52b70f.png)
The problem I see with this is that it is difficult to say where the tab belongs to. Using the round edges it seems to belong to the body. But the colour of the tab is different from that of the body. Code does a good job in integrating it with the color of the body. Basing on the colour of the tabs I would assume it belongs to the header bar/ title bar. Then the rounded corners of the tab is very misleading. The PR tries to solve this by removing the rounded edges. Here is how it looks now:
![screenshot from 2018-12-02 11 34 57](https://user-images.githubusercontent.com/437678/49338776-19189900-f627-11e8-832e-df528159537f.png)
