### PR TITLE
Update .seek-bar scale slider style.

### DIFF
--- a/elementary/gtk-3.0/granite-widgets.css
+++ b/elementary/gtk-3.0/granite-widgets.css
@@ -205,6 +205,8 @@
     background: transparent;
     border: transparent;
     box-shadow: none;
+    min-width: 0;
+    min-height: 0;
 }
 
 /**************


### PR DESCRIPTION
Fixes #301
Seek bar slider should be zero in width and height, it's not shown, but if there's width or height the seek bar will not exactly go where you clicked.

Before:
![screen record from 2018-12-16 08 26 50](https://user-images.githubusercontent.com/1688821/50051538-64917380-010c-11e9-938f-542f913d14c5.gif)

After:
![screen record from 2018-12-16 08 25 37](https://user-images.githubusercontent.com/1688821/50051539-665b3700-010c-11e9-9bb4-cb31275cf700.gif)
