### PR TITLE
Shade switches with white overlay

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2080,14 +2080,18 @@ switch:focus slider {
 }
 
 switch:checked {
+    background-color: @colorAccent;
     background-image:
         linear-gradient(
             to bottom,
-            shade (
-                @colorAccent,
-                1.2
+            alpha (
+                #fff,
+                0.3
             ),
-            @colorAccent
+            alpha (
+                #fff,
+                0
+            )
         );
     border-color: shade(@colorAccent, 0.85);
 }


### PR DESCRIPTION
Turns out that shade works okay for dark colors like blue, but looks like garbage for green. Instead, overlay white:

![screenshot from 2018-12-27 18 40 45 2x](https://user-images.githubusercontent.com/7277719/50500562-0ebfa400-0a07-11e9-9eef-b1957bafabc1.png)

![screenshot from 2018-12-27 18 41 44 2x](https://user-images.githubusercontent.com/7277719/50500563-0ebfa400-0a07-11e9-83fa-5e138a444727.png)
