### PR TITLE
Changes dialog label.primary to em font sizing

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -4066,7 +4066,7 @@ dialog toolbar {
 
 dialog label.primary {
     font-weight: 700;
-    font-size: 11pt;
+    font-size: 1.2em;
 }
 
 /***************


### PR DESCRIPTION
I have no idea why, but this gives us slightly tighter kerning :man_shrugging: 

![Screenshot from 2019-04-05 21 03 27@2x](https://user-images.githubusercontent.com/7277719/55664689-14d3d680-57e7-11e9-8683-52f260166fa2.png)
