### PR TITLE
Fix inline notebook being 1px smaller when only one tab is open

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -1802,6 +1802,11 @@ notebook tab label:backdrop {
     border-color: shade (@tab_base_color, 0.78);
 }
 
+.inline-toolbar notebook tab {
+    margin-bottom: -1px;
+    margin-top: 1px;
+}
+
 .inline-toolbar notebook tab:checked {
     background-color: @tab_base_color;
     background-image: none;
@@ -1809,7 +1814,6 @@ notebook tab label:backdrop {
     box-shadow:
         -1px 0 1px alpha (#000, 0.05),
         1px 0 1px alpha (#000, 0.05);
-    margin-bottom: -1px;
 }
 
 /*************


### PR DESCRIPTION
before:
![old](https://user-images.githubusercontent.com/805017/57572371-70facd80-7419-11e9-85f5-062f2fe3a0ec.gif)

after:
![new](https://user-images.githubusercontent.com/805017/57572366-6b04ec80-7419-11e9-8587-d23bea25d5e3.gif)

I have also added 1px top margin so that it has the same height as normal tab, and in Code it also aligns nicely to stackswitcher on left.