### PR TITLE
Disable transitions on checkitems

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2095,6 +2095,7 @@ menuitem check {
     background: none;
     border-color: transparent;
     box-shadow: none;
+    transition: none;
 }
 
 menuitem check:dir(ltr),


### PR DESCRIPTION
A follow up to https://github.com/elementary/gala/pull/534. Disables transitions on checkitems so that we don't have transitions when a menu pops up.