### PR TITLE
Fix the border color of insensitive button with suggested class in dark mode

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets-dark.css
+++ b/elementary/gtk-3.0/gtk-widgets-dark.css
@@ -572,8 +572,8 @@ EggFindBar.toolbar,
 * Suggested Action Button *
 **************************/
 
-button.suggested-action,
-.suggested-action.button {
+button.suggested-action:not(:disabled),
+.suggested-action.button:not(:disabled) {
     border: 1px solid shade (@selected_bg_color, 0.35);
 }
 


### PR DESCRIPTION
Fixes #511

## BEFORE

![2019-06-01 09 42 04 の画面録画@2x](https://user-images.githubusercontent.com/26003928/58741307-6c429b80-8452-11e9-8ce7-e8702d4d3413.gif)

Insensitive buttons with `Gtk.STYLE_CLASS_SUGGESTED_ACTION` class have blue border color in dark mode.

## AFTER

![2019-06-01 09 40 12 の画面録画@2x](https://user-images.githubusercontent.com/26003928/58741306-6baa0500-8452-11e9-8f44-e219f67c403a.gif)

Those buttons no longer have blue border color in dark mode.
