### PR TITLE
Add undershoot to popovers

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3754,6 +3754,22 @@ popover.menu,
     background-image: none;
 }
 
+popover undershoot.top {
+    background:
+        linear-gradient(
+            @bg_color 0%,
+            alpha(@bg_color, 0) 50%
+        );
+}
+
+popover undershoot.bottom {
+    background:
+        linear-gradient(
+            alpha(@bg_color, 0) 50%,
+            @bg_color 100%
+        );
+}
+
 .popover > .location-bar,
 .popover.osd > .toolbar,
 .popover.osd > .inline-toolbar,


### PR DESCRIPTION
Undershoots help smooth out the edges of scrollable widgets. We opted to look at it on a widget-by-widget basis in #340, so here's the start of that for popovers.

<!--
# Before

![Screenshot from 2019-07-02 17 31 53@2x](https://user-images.githubusercontent.com/611168/60553248-999f9500-9cef-11e9-9837-7bd9d2be7080.png)

![Screenshot from 2019-07-02 17 32 02@2x](https://user-images.githubusercontent.com/611168/60553249-9c01ef00-9cef-11e9-91be-79edd9e9d8bc.png)


# After

![Screenshot from 2019-07-02 17 31 26@2x](https://user-images.githubusercontent.com/611168/60553239-88ef1f00-9cef-11e9-82c8-91ac85fc2fff.png)

![Screenshot from 2019-07-02 17 31 37@2x](https://user-images.githubusercontent.com/611168/60553246-8ee50000-9cef-11e9-97bc-bb46252df2bc.png)
-->

## Before

Notice the hard edges on the user list.

![Before](https://user-images.githubusercontent.com/523210/60992755-6abb9b80-a34d-11e9-8be0-4f5d53522a66.png)

## After

Soft edges on the user list.

![After](https://user-images.githubusercontent.com/523210/60992804-87f06a00-a34d-11e9-820b-c581f634313f.png)