### PR TITLE
Explicitly set color inside keycaps

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -164,6 +164,7 @@ rubberband,
         inset 0 -2px 0 0 alpha (@bg_highlight_color, 0.15),
         inset 0 -1px 0 0 shade (@bg_color, 0.85),
         0 1px 2px alpha (#000, 0.05);
+    color: @text_color;
     font-size: 85%;
     min-width: 12px;
     padding: 3px 6px 4px;


### PR DESCRIPTION
Fixes an issue where keycaps inside list rows have white text