### PR TITLE
Use the same popover shadow everywhere

### DIFF
--- a/elementary/gtk-3.0/apps.css
+++ b/elementary/gtk-3.0/apps.css
@@ -362,13 +362,6 @@ menubar.panel,
     text-shadow: none;
 }
 
-.panel popover {
-    box-shadow:
-        inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.5),
-        0 3px 4px alpha (#000, 0.15),
-        0 3px 3px -3px alpha (#000, 0.35);
-}
-
 /**********
  * Photos *
  *********/

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3746,9 +3746,9 @@ popover.osd,
     background-color: @bg_color;
     box-shadow:
         inset 0 -1px 0 0 alpha (@bg_highlight_color, 0.5),
-        0 3px 6px alpha (#000, 0.16),
-        0 3px 6px alpha (#000, 0.23);
-    margin: 10px 6px;
+        0 3px 4px alpha (#000, 0.15),
+        0 3px 3px -3px alpha (#000, 0.35);
+    margin: 6px;
     text-shadow: none;
 }
 


### PR DESCRIPTION
Uses the smaller popover shadow from the panel everywhere and reduce margins (which I'm not sure actually does anything anymore, tbh)