### PR TITLE
Remove duplicated search-bar style

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets-dark.css
+++ b/elementary/gtk-3.0/gtk-widgets-dark.css
@@ -563,18 +563,6 @@ EggFindBar.toolbar,
     -gtk-icon-shadow: 0 1px alpha (#000, 0.1);
 }
 
-/***************
- * Search bars *
- ***************/
-
-EggFindBar.toolbar,
-.search-bar {
-    box-shadow:
-        inset 0 0 0 1px alpha (#fff, 0.01),
-        inset 0 1px 0 0 alpha (#fff, 0.05),
-        inset 0 -1px 0 0 alpha (#fff, 0.03);
-}
-
 /**************************
 * Suggested Action Button *
 **************************/


### PR DESCRIPTION
Am I crazy? It's both here:

https://github.com/elementary/stylesheet/blob/d3a440867733185b6c09103be990e94be0468976/elementary/gtk-3.0/gtk-widgets-dark.css#L446-L456

and here (which this removes):

https://github.com/elementary/stylesheet/blob/d3a440867733185b6c09103be990e94be0468976/elementary/gtk-3.0/gtk-widgets-dark.css#L566-L576