### PR TITLE
Change window shadows to be softer

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -3883,8 +3883,7 @@ decoration {
     border-radius: 4px 4px 0 0;
     box-shadow:
         0 0 0 1px @decoration_border_color,
-        0 14px 28px rgba(0, 0, 0, 0.35),
-        0 10px 10px rgba(0, 0, 0, 0.22);
+        0 10px 20px 0 alpha (#000, 0.4);
     margin: 12px;
 }
 
@@ -3901,8 +3900,8 @@ window.popup decoration,
 menu window.popup decoration,
 menu .csd.popup decoration {
     box-shadow:
-        0 0 0 1px alpha (#000, 0.2),
-        0 10px 20px alpha (#000, 0.19),
+        0 0 0 1px alpha (#000, 0.1),
+        0 10px 20px 0 alpha (#000, 0.23),
         0 6px 6px alpha (#000, 0.23);
 }
 
@@ -3923,9 +3922,8 @@ tooltip decoration {
 decoration:backdrop {
     box-shadow:
         0 0 0 1px alpha (#000, 0.2),
-        0 3px 6px alpha (#000, 0.16),
-        0 3px 6px alpha (#000, 0.23),
-        0 14px 28px transparent;
+        0 5px 10px alpha (#000, 0.2),
+        0 10px 20px transparent;
 }
 
 .maximized decoration {


### PR DESCRIPTION
With this PR:
- Inactive windows don't clash with active windows.
- Reduces the current visual ugliness of overlapping many windows shadows.

Looks like this:
![Screenshot from 2019-09-27 01 50 28](https://user-images.githubusercontent.com/4886639/65743181-e36b0200-e0c9-11e9-8c3b-eecb75b39957.png)

NOTE: This doesn't fix the above for legacy windows.