### PR TITLE
Use new BadgeColor property to color Strawberry 300

### DIFF
--- a/elementary/gtk-3.0/granite-widgets.css
+++ b/elementary/gtk-3.0/granite-widgets.css
@@ -612,7 +612,9 @@ window.rounded decoration {
 * Text Styles *
 **************/
 
-.accent {
+.accent,
+.titlebar.flat .accent image,
+.titlebar.flat .accent label {
     color: @colorAccent;
 }
 

--- a/elementary/plank/dock.theme
+++ b/elementary/plank/dock.theme
@@ -56,8 +56,8 @@ GlowSize=0
 GlowTime=0
 #The time (in ms) of each pulse of the hidden-dock urgent glow.
 GlowPulseTime=0
-#The hue-shift (-180 to 180) of the urgent indicator color.
-UrgentHueShift=150
+#The color of the urgent indicator or badge.
+BadgeColor=198;;38;;46;;255
 #The time (in ms) to move an item to its new position or its addition/removal to/from the dock.
 ItemMoveTime=200
 #Whether background and icons will unhide/hide with different speeds. The top-border of both will leave/hit the screen-edge at the same time.

--- a/elementary/plank/dock.theme
+++ b/elementary/plank/dock.theme
@@ -57,7 +57,7 @@ GlowTime=0
 #The time (in ms) of each pulse of the hidden-dock urgent glow.
 GlowPulseTime=0
 #The color of the urgent indicator or badge.
-BadgeColor=198;;38;;46;;255
+BadgeColor=237;;83;;83;;255
 #The time (in ms) to move an item to its new position or its addition/removal to/from the dock.
 ItemMoveTime=200
 #Whether background and icons will unhide/hide with different speeds. The top-border of both will leave/hit the screen-edge at the same time.


### PR DESCRIPTION
Fixes #545 

This makes the badge or urgent indicator's background color always the intended red.

EDIT: Strawberry 300 looks more like the old red.
![Screenshot from 2019-09-27 17 09 56](https://user-images.githubusercontent.com/4886639/65799079-a5152780-e149-11e9-86d1-131f9f63816f.png)
