### PR TITLE
Tighten kerning on h1 and h2 labels

### DIFF
--- a/elementary/gtk-3.0/granite-widgets.css
+++ b/elementary/gtk-3.0/granite-widgets.css
@@ -586,11 +586,13 @@ window.rounded decoration {
 
 .h1 {
     font-size: 24pt;
+    letter-spacing: -0.05em;
 }
 
 .h2 {
     font-weight: 300;
     font-size: 18pt;
+    letter-spacing: -0.05em;
 }
 
 .h3 {

--- a/elementary/gtk-3.0/granite-widgets.css
+++ b/elementary/gtk-3.0/granite-widgets.css
@@ -586,7 +586,7 @@ window.rounded decoration {
 
 .h1 {
     font-size: 24pt;
-    letter-spacing: -0.05em;
+    letter-spacing: -0.04em;
 }
 
 .h2 {


### PR DESCRIPTION
Following a rabbit hole after seeing a @steveschoger tweet. The reasoning here is that since title text is larger the space between letters is also larger and makes it feel like letter spacing in titles is looser than in body text. Reducing the letter spacing in titles makes it feel like title and body text are spaced the same. Kind of interesting. Anyways, here's what it looks like in practice:

## BEFORE
![Screenshot from 2019-12-13 15 59 44@2x](https://user-images.githubusercontent.com/7277719/70839617-6561f180-1dc2-11ea-91a1-c55d223c2e3d.png)
![Screenshot from 2019-12-13 16 01 06@2x](https://user-images.githubusercontent.com/7277719/70839620-65fa8800-1dc2-11ea-803c-420e0d2ed476.png)

## AFTER
![Screenshot from 2019-12-13 15 59 30@2x](https://user-images.githubusercontent.com/7277719/70839616-6561f180-1dc2-11ea-9452-a8fedb4a28bf.png)
![Screenshot from 2019-12-13 16 00 56@2x](https://user-images.githubusercontent.com/7277719/70839619-6561f180-1dc2-11ea-9ff7-1eb37c388e0f.png)

