### PR TITLE
Improve contrast in text selections

### DIFF
--- a/data/stylesheet.appdata.xml.in
+++ b/data/stylesheet.appdata.xml.in
@@ -14,6 +14,11 @@
     <id>io.elementary.stylesheet</id>
   </provides>
   <releases>
+    <release version="5.4.1" date="2020-01-02" urgency="medium">
+      <ul>
+        <li>Improve contrast in text selections</li>
+      </ul>
+    </release>
     <release version="5.4.0" date="2019-12-23" urgency="medium">
       <description>
         <p>New features:</p>

--- a/elementary/gtk-3.0/brand-dark.css
+++ b/elementary/gtk-3.0/brand-dark.css
@@ -16,6 +16,13 @@
 * with the elementary GTK theme. If not, see http://www.gnu.org/licenses/.
 */
 
+/* Accent Shades */
+@define-color accent_color_100 @BLUEBERRY_100;
+@define-color accent_color_300 @BLUEBERRY_300;
+@define-color accent_color_500 @BLUEBERRY_500;
+@define-color accent_color_700 @BLUEBERRY_700;
+@define-color accent_color_900 @BLUEBERRY_900;
+
 /* Brand Colors */
 @define-color colorPrimary @titlebar_color;
 @define-color colorAccent @selected_bg_color;

--- a/elementary/gtk-3.0/brand.css
+++ b/elementary/gtk-3.0/brand.css
@@ -16,6 +16,13 @@
 * with the elementary GTK theme. If not, see http://www.gnu.org/licenses/.
 */
 
+/* Accent Shades */
+@define-color accent_color_100 @BLUEBERRY_100;
+@define-color accent_color_300 @BLUEBERRY_300;
+@define-color accent_color_500 @BLUEBERRY_500;
+@define-color accent_color_700 @BLUEBERRY_700;
+@define-color accent_color_900 @BLUEBERRY_900;
+
 /* Brand Colors */
 @define-color colorPrimary @titlebar_color;
 @define-color colorAccent @selected_bg_color;

--- a/elementary/gtk-3.0/gtk-widgets-dark.css
+++ b/elementary/gtk-3.0/gtk-widgets-dark.css
@@ -59,9 +59,10 @@ entry:focus,
         0 1px 0 0 alpha(#fff, 0.05);
 }
 
-entry selection,
-textview selection {
-    color: shade (@text_color, 1.23);
+selection {
+    background-color: alpha (@accent_color_500, 0.3);
+    color: mix (@text_color, @accent_color_100, 0.75);
+    text-shadow: none;
 }
 
 .titlebar entry:disabled,

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -333,8 +333,8 @@ spinbutton,
 }
 
 selection {
-    background-color: @colorAccent;
-    color: @selected_fg_color;
+    background-color: alpha (@accent_color_100, 0.3);
+    color: @accent_color_900;
     text-shadow: none;
 }
 


### PR DESCRIPTION
Contrast here goes from 2.8:1 to 8.8:1 in the light style and from  2.8:1 to 5.1:1 in the dark style. So oddly the effect looks less jarring but is way more contrasty

## BEFORE
![Screenshot from 2020-01-02 10 15 20@2x](https://user-images.githubusercontent.com/7277719/71684000-f2a4c000-2d48-11ea-8a29-839276a51375.png)

![Screenshot from 2020-01-02 10 33 03@2x](https://user-images.githubusercontent.com/7277719/71684788-46b0a400-2d4b-11ea-80ce-063bd1710230.png)


## AFTER
![Screenshot from 2020-01-02 10 13 57@2x](https://user-images.githubusercontent.com/7277719/71683998-f2a4c000-2d48-11ea-94fb-132aaa5a457f.png)


![Screenshot from 2020-01-02 10 25 23@2x](https://user-images.githubusercontent.com/7277719/71684763-313b7a00-2d4b-11ea-95eb-4fcf8b901a04.png)

