### PR TITLE
gtk-widgets: hide images from inside switches

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2328,7 +2328,8 @@ checkbutton label:dir(rtl) {
     margin-right: 6px;
 }
 
-switch image {
+switch > image,
+popover switch > image {
     color: transparent;
     -gtk-icon-shadow: none;
 }

--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -2329,6 +2329,7 @@ checkbutton label:dir(rtl) {
 }
 
 switch > image,
+switch > image:disabled,
 popover switch > image {
     color: transparent;
     -gtk-icon-shadow: none;


### PR DESCRIPTION
Be more specific so we don't get images in switches in popovers