### PR TITLE
Dry imports

### DIFF
--- a/src/_mixins-dark.scss
+++ b/src/_mixins-dark.scss
@@ -23,3 +23,5 @@
             0 10px 10px rgba(0, 0, 0, 0.32);
     }
 }
+
+@import 'widgets/_widgets.scss';

--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -23,3 +23,5 @@
             0 10px 10px rgba(0, 0, 0, 0.22);
     }
 }
+
+@import 'widgets/_widgets.scss';

--- a/src/banana/banana-dark.scss
+++ b/src/banana/banana-dark.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @BANANA_300;
 @define-color accent_color_900 @BANANA_100;
 
-@import '../widgets/_mixins-dark.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins-dark.scss';

--- a/src/banana/banana.scss
+++ b/src/banana/banana.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @BANANA_700;
 @define-color accent_color_900 @BANANA_900;
 
-@import '../widgets/_mixins.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins.scss';

--- a/src/blueberry/blueberry-dark.scss
+++ b/src/blueberry/blueberry-dark.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @BLUEBERRY_300;
 @define-color accent_color_900 @BLUEBERRY_100;
 
-@import '../widgets/_mixins-dark.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins-dark.scss';

--- a/src/blueberry/blueberry.scss
+++ b/src/blueberry/blueberry.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @BLUEBERRY_700;
 @define-color accent_color_900 @BLUEBERRY_900;
 
-@import '../widgets/_mixins.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins.scss';

--- a/src/bubblegum/bubblegum-dark.scss
+++ b/src/bubblegum/bubblegum-dark.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @BUBBLEGUM_300;
 @define-color accent_color_900 @BUBBLEGUM_100;
 
-@import '../widgets/_mixins-dark.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins-dark.scss';

--- a/src/bubblegum/bubblegum.scss
+++ b/src/bubblegum/bubblegum.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @BUBBLEGUM_700;
 @define-color accent_color_900 @BUBBLEGUM_900;
 
-@import '../widgets/_mixins.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins.scss';

--- a/src/grape/grape-dark.scss
+++ b/src/grape/grape-dark.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @GRAPE_300;
 @define-color accent_color_900 @GRAPE_100;
 
-@import '../widgets/_mixins-dark.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins-dark.scss';

--- a/src/grape/grape.scss
+++ b/src/grape/grape.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @GRAPE_700;
 @define-color accent_color_900 @GRAPE_900;
 
-@import '../widgets/_mixins.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins.scss';

--- a/src/lime/lime-dark.scss
+++ b/src/lime/lime-dark.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @LIME_300;
 @define-color accent_color_900 @LIME_100;
 
-@import '../widgets/_mixins-dark.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins-dark.scss';

--- a/src/lime/lime.scss
+++ b/src/lime/lime.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @LIME_700;
 @define-color accent_color_900 @LIME_900;
 
-@import '../widgets/_mixins.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins.scss';

--- a/src/mint/mint-dark.scss
+++ b/src/mint/mint-dark.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @MINT_300;
 @define-color accent_color_900 @MINT_100;
 
-@import '../widgets/_mixins-dark.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins-dark.scss';

--- a/src/mint/mint.scss
+++ b/src/mint/mint.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @MINT_700;
 @define-color accent_color_900 @MINT_900;
 
-@import '../widgets/_mixins.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins.scss';

--- a/src/orange/orange-dark.scss
+++ b/src/orange/orange-dark.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @ORANGE_300;
 @define-color accent_color_900 @ORANGE_100;
 
-@import '../widgets/_mixins-dark.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins-dark.scss';

--- a/src/orange/orange.scss
+++ b/src/orange/orange.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @ORANGE_700;
 @define-color accent_color_900 @ORANGE_900;
 
-@import '../widgets/_mixins.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins.scss';

--- a/src/strawberry/strawberry-dark.scss
+++ b/src/strawberry/strawberry-dark.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @STRAWBERRY_300;
 @define-color accent_color_900 @STRAWBERRY_100;
 
-@import '../widgets/_mixins-dark.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins-dark.scss';

--- a/src/strawberry/strawberry.scss
+++ b/src/strawberry/strawberry.scss
@@ -26,5 +26,4 @@
 @define-color accent_color_700 @STRAWBERRY_700;
 @define-color accent_color_900 @STRAWBERRY_900;
 
-@import '../widgets/_mixins.scss';
-@import '../widgets/_widgets.scss';
+@import '../_mixins.scss';


### PR DESCRIPTION
It's gonna be too much maintenance to update these color scheme files each time we add a new import, so instead:

* move mixins to /src because they're not really widgets right?
* Have mixins import widgets