### PR TITLE
Greenfield: correct color-scheme for orange-dark

### DIFF
--- a/src/orange/orange-dark.scss
+++ b/src/orange/orange-dark.scss
@@ -26,6 +26,6 @@
 @define-color accent_color_700 @ORANGE_300;
 @define-color accent_color_900 @ORANGE_100;
 
-$color-scheme: "light";
+$color-scheme: "dark";
 
 @import '../_mixins.scss';


### PR DESCRIPTION
Whoops, looks like we missed this.