### PR TITLE
Add button styles

### DIFF
--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -135,18 +135,14 @@ $toplevel-border-color: rgba(0, 0, 0, 0.2);
     @return $highlight;
 }
 
-// elements with outset border style like headerbars, buttons, checkboxes, etc
-%border-outset {
+// Background for elements with outset style like headerbars, buttons, checkboxes, etc
+%background-outset {
     background-image:
         linear-gradient(
             to bottom,
             #{'alpha(@highlight_color, 0.2)'},
             rgba(255, 255, 255, 0)
         );
-    box-shadow:
-        outset-highlight("full"),
-        0 0 0 1px rgba(0, 0, 0, 0.15),
-        0 1px 2px rgba(0, 0, 0, 0.2);
 
     &:backdrop {
         background-image:
@@ -155,10 +151,6 @@ $toplevel-border-color: rgba(0, 0, 0, 0.2);
                 #{'alpha(@highlight_color, 0.35)'},
                 #{'alpha(@highlight_color, 0.3)'}
             );
-        box-shadow:
-            outset-highlight("full"),
-            0 0 0 1px rgba(0, 0, 0, 0.1),
-            0 1px 2px rgba(0, 0, 0, 0.15);
     }
 }
 

--- a/src/widgets/_widgets.scss
+++ b/src/widgets/_widgets.scss
@@ -102,6 +102,8 @@ dialog {
 button {
     background-clip: padding-box;
     border-radius: 3px;
+    //Explicitly set in case containers override default color
+    color: $fg-color;
     //Off-by-one to account for padding-box clip
     padding: 4px 7px;
     transition: all 100ms ease-in;

--- a/src/widgets/_widgets.scss
+++ b/src/widgets/_widgets.scss
@@ -113,7 +113,7 @@ button {
         box-shadow:
             outset-highlight("full"),
             0 1px 1px rgba(0, 0, 0, 0.03),
-	        0 1px 2px rgba(0, 0, 0, 0.1);
+            0 1px 2px rgba(0, 0, 0, 0.1);
 
         &.titlebutton:not(:active) {
             background: none;

--- a/src/widgets/_widgets.scss
+++ b/src/widgets/_widgets.scss
@@ -46,7 +46,7 @@ window:not(.popup) {
     }
 
     .titlebar {
-        @extend %border-outset;
+        @extend %background-outset;
         background-color: #{"@color_primary"};
         box-shadow:
             outset-highlight("full"),
@@ -96,6 +96,63 @@ dialog {
             font-size: 0.1px; // Workaround for an issue in Gtk when setting 0px
             color: transparent;
         }
+    }
+}
+
+button {
+    background-clip: padding-box;
+    border-radius: 3px;
+    //Off-by-one to account for padding-box clip
+    padding: 4px 7px;
+    transition: all 100ms ease-in;
+
+    &:not(.image-button):not(.flat) {
+        @extend %background-outset;
+        background-color: bg-color(2);
+        border: 1px solid rgba(0, 0, 0, 0.2);
+        box-shadow:
+            outset-highlight("full"),
+            0 1px 1px rgba(0, 0, 0, 0.03),
+	        0 1px 2px rgba(0, 0, 0, 0.1);
+
+        &.titlebutton:not(:active) {
+            background: none;
+            border-color: transparent;
+            box-shadow: none;
+        }
+
+        &:active,
+        &:checked {
+            background: rgba(0, 0, 0, 0.05);
+            box-shadow: inset-shadow("");
+        }
+
+        &:disabled {
+            background: rgba(0, 0, 0, 0.03);
+            box-shadow:
+                outset-highlight("full"),
+                0 1px 0 0 #{'alpha(@highlight_color, 0.3)'};
+        }
+    }
+
+    &:disabled {
+        color: #{'@placeholder_text_color'};
+    }
+
+    &.combo,
+    &.image-button,
+    &.titlebutton {
+        padding: 4px;
+    }
+
+    arrow {
+        min-width: 16px;
+        min-height: 16px;
+        -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
+    }
+
+    label {
+        font-weight: 500;
     }
 }
 


### PR DESCRIPTION
did a little bit of YAGNI with the outset element style. This will change in future branches, but titlebars don't use the same kind of border and shadow as buttons (or other outset elements like checks). So when we add checks and radios, we can figure out what's the best way to DRY their shadows

Doesn't try to account for focus styles or linked buttons, but should cover most common button styles