### PR TITLE
Greenfield: Use ems for padding

### DIFF
--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -135,6 +135,18 @@ $toplevel-border-color: rgba(0, 0, 0, 0.2);
     @return $highlight;
 }
 
+@function em($pixels, $text-size: 9pt) {
+    @if (unitless($pixels)) {
+        $pixels: $pixels * 1px;
+    }
+
+    @if (unitless($text-size)) {
+        $text-size: $text-size * 1px;
+    }
+
+    @return $pixels / $text-size * 1em;
+}
+
 // Background for elements with outset style like headerbars, buttons, checkboxes, etc
 %background-outset {
     background-image:

--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -4,7 +4,7 @@ button {
     // Explicitly set in case containers override default color
     color: $fg-color;
     // Off-by-one to account for padding-box clip
-    padding: 4px 7px;
+    padding: em(4px) em(7px);
     transition: all 100ms ease-in;
 
     &:not(.image-button):not(.flat) {
@@ -43,7 +43,7 @@ button {
     &.combo,
     &.image-button,
     &.titlebutton {
-        padding: 4px;
+        padding: em(4px);
     }
 
     arrow {

--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -1,6 +1,6 @@
 button {
     background-clip: padding-box;
-    border-radius: 3px;
+    border-radius: em(3px);
     // Explicitly set in case containers override default color
     color: #{'@fg_color'};
     // Off-by-one to account for padding-box clip
@@ -46,8 +46,8 @@ button {
     }
 
     arrow {
-        min-width: 16px;
-        min-height: 16px;
+        min-width: em(16px);
+        min-height: em(16px);
         -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
     }
 

--- a/src/widgets/_cards.scss
+++ b/src/widgets/_cards.scss
@@ -6,6 +6,7 @@
     background-color: bg-color(1);
     box-shadow:
         outset-highlight(),
+        // Intentionally not in ems since it's used as a stroke
         0 0 0 1px rgba(0, 0, 0, 0.1),
         shadow(2);
     transition: all 150ms ease-in-out;
@@ -14,6 +15,7 @@
         background-color: bg-color(2);
         box-shadow:
             outset-highlight(),
+            // Intentionally not in ems since it's used as a stroke
             0 0 0 1px rgba(0, 0, 0, 0.1),
             shadow(1);
     }

--- a/src/widgets/_entries.scss
+++ b/src/widgets/_entries.scss
@@ -5,7 +5,7 @@ entry {
     border-radius: 3px;
     box-shadow: inset-shadow("");
     // Off-by-one to account for padding-box clip
-    padding: 4px;
+    padding: em(4px);
 
     &:disabled {
         background: rgba(0,0,0,0.03);
@@ -19,11 +19,11 @@ entry {
     }
 
     image.left {
-        margin-right: 6px;
+        margin-right: em(6px);
     }
 
     image.right {
-        margin-left: 6px;
+        margin-left: em(6px);
     }
 
     // We only want the action side icon to react on hover

--- a/src/widgets/_entries.scss
+++ b/src/widgets/_entries.scss
@@ -2,7 +2,7 @@ entry {
     background-color: bg-color(1);
     background-clip: padding-box;
     border: 1px solid $toplevel-border-color;
-    border-radius: 3px;
+    border-radius: em(3px);
     box-shadow: inset-shadow("");
     color: #{'@fg_color'};
     // Off-by-one to account for padding-box clip

--- a/src/widgets/_panes.scss
+++ b/src/widgets/_panes.scss
@@ -19,6 +19,6 @@ paned.horizontal > separator {
             );
     }
     // This creates the invisible resize handle
-    margin-right: -7px;
-    min-width: 8px;
+    margin-right: em(-7px);
+    min-width: em(8px);
 }

--- a/src/widgets/_popovers.scss
+++ b/src/widgets/_popovers.scss
@@ -1,7 +1,7 @@
 popover {
     background-clip: padding-box;
     border: 1px solid $toplevel-border-color;
-    border-radius: 6px;
+    border-radius: em(6px);
     box-shadow: shadow(2);
     margin: 6px;
 }

--- a/src/widgets/_scales.scss
+++ b/src/widgets/_scales.scss
@@ -21,13 +21,13 @@ scale {
     slider {
         @extend %outset-background;
         background-color: bg-color(2);
-        border-radius: 12px;
+        border-radius: em(12px);
         box-shadow:
             outset-highlight(),
             0 0 0 1px rgba(0, 0, 0, 0.25),
             0 1px 1px 1px rgba(0, 0, 0, 0.1);
-        min-height: 14px;
-        min-width: 14px;
+        min-height: em(14px);
+        min-width: em(14px);
 
         &:backdrop {
             box-shadow:
@@ -46,11 +46,11 @@ scale {
 
     trough {
         border: 1px solid rgba(0, 0, 0, 0.2);
-        border-radius: 12px;
+        border-radius: em(12px);
         background-color: rgba(0, 0, 0, 0.05);
         box-shadow: inset-shadow();
-        min-height: 3px;
-        min-width: 3px;
+        min-height: em(3px);
+        min-width: em(3px);
 
         &:disabled {
             background-image: none;
@@ -70,56 +70,58 @@ scale {
     &.horizontal {
         highlight.top,
         fill.top {
-            border-radius: 12px 0 0 12px;
-            margin: 0 0 0 -6px;
+            border-radius: em(12px) 0 0 em(12px);
+            margin: 0 0 0 em(-6px);
         }
 
         highlight.bottom,
         fill.bottom {
-            border-radius: 0 12px 12px 0;
-            margin: 0 -6px 0 0;
+            border-radius: 0 em(12px) em(12px) 0;
+            margin: 0 em(-6px) 0 0;
         }
 
         mark indicator {
-            min-height: 6px;
+            min-height: em(6px);
+            // Intentionally not in ems since it's a stroke
             min-width: 1px;
         }
 
         slider {
-            margin: -6px 0;
+            margin: em(-6px) 0;
         }
 
         trough {
-            margin: 6px 0;
-            padding: 0 6px;
+            margin: em(6px) 0;
+            padding: 0 em(6px);
         }
     }
 
     &.vertical {
         highlight.top,
         fill.top {
-            border-radius: 12px 12px 0 0;
-            margin: -6px 0 0;
+            border-radius: em(12px) em(12px) 0 0;
+            margin: em(-6px) 0 0;
         }
 
         highlight.bottom,
         fill.bottom {
-            border-radius: 0 0 12px 12px;
-            margin: 0 0 -6px;
+            border-radius: 0 0 em(12px) em(12px);
+            margin: 0 0 em(-6px);
         }
 
         mark indicator {
+            // Intentionally not in ems since it's a stroke
             min-height: 1px;
-            min-width: 6px;
+            min-width: em(6px);
         }
 
         slider {
-            margin: 0 -6px;
+            margin: 0 em(-6px);
         }
 
         trough {
-            margin: 0 6px;
-            padding: 6px 0;
+            margin: 0 em(6px);
+            padding: em(6px) 0;
         }
     }
 }

--- a/src/widgets/_sidebars.scss
+++ b/src/widgets/_sidebars.scss
@@ -1,11 +1,11 @@
 .sidebar {
     list {
         background-color: bg_color(3);
-        padding-top: 6px;
-        border-bottom-left-radius: 6px;
+        padding-top: em(6px);
+        border-bottom-left-radius: em(6px);
 
         row {
-            padding: 6px 12px;
+            padding: em(6px) em(12px);
 
             &:hover {
                 background-color: rgba(255, 255, 255, 0.75);

--- a/src/widgets/_switches.scss
+++ b/src/widgets/_switches.scss
@@ -2,7 +2,7 @@ switch {
     background-color: rgba(0, 0, 0, 0.05);
     border: 1px solid rgba(0, 0, 0, 0.2);
     box-shadow: inset-shadow();
-    border-radius: 16px;
+    border-radius: em(16px);
     transition: all 200ms ease-in;
 
     &:checked:not(.mode-switch):not(:backdrop) {
@@ -24,13 +24,13 @@ switch {
             outset-highlight("full"),
             0 0 0 1px rgba(0, 0, 0, 0.2),
             outset-shadow(3);
-        min-height: 24px;
-        min-width: 24px;
+        min-height: em(24px);
+        min-width: em(24px);
     }
 
     &.mode-switch slider {
-        min-height: 16px;
-        min-width: 16px;
+        min-height: em(16px);
+        min-width: em(16px);
     }
 
     &:disabled {

--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -1,10 +1,10 @@
 window:not(.popup),
 dialog {
-    border-radius: 0 0 6px 6px;
+    border-radius: 0 0 em(6px) em(6px);
 
     > decoration {
-        border-radius: 6px;
-        margin: 12px;
+        border-radius: em(6px);
+        margin: em(12px);
 
         &:backdrop {
             box-shadow: shadow(2);
@@ -12,11 +12,12 @@ dialog {
     }
 
     > headerbar.titlebar {
-        border-radius: 6px 6px 0 0;
+        border-radius: em(6px) em(6px) 0 0;
     }
 }
 
 window:not(.popup) {
+    // Intentionally not in ems since it's used as a stroke
     box-shadow: 0 0 0 1px $toplevel-border-color;
 
     > decoration {
@@ -38,22 +39,24 @@ window:not(.popup) {
         background-color: #{"@color_primary"};
         box-shadow:
             outset-highlight("full"),
+            // Intentionally not in ems since it's used as a stroke
             0 0 0 1px #{'alpha(shade(@color_primary, 0.7), 0.4)'},
-            0 1px 2px rgba(0, 0, 0, 0.2);
+            0 em(1px) em(2px) rgba(0, 0, 0, 0.2);
         padding: 6px;
 
         @if $color-scheme == "dark" {
             box-shadow:
                 outset-highlight("full"),
+                // Intentionally not in ems since it's used as a stroke
                 0 0 0 1px #{'alpha(shade(@color_primary, 0.5), 0.5)'},
-                0 1px 2px rgba(0, 0, 0, 0.2);
+                0 em(1px) em(2px) rgba(0, 0, 0, 0.2);
         }
 
         &:backdrop {
             box-shadow:
                 outset-highlight("full"),
                 0 0 0 1px #{'alpha(shade(@color_primary, 0.7), 0.3)'},
-                0 1px 2px rgba(0, 0, 0, 0.15);
+                0 em(1px) em(2px) rgba(0, 0, 0, 0.15);
         }
 
 	    .title {
@@ -67,11 +70,13 @@ dialog {
 
     > decoration {
         box-shadow:
+            // Intentionally not in ems since it's used as a stroke
             0 0 0 1px $toplevel-border-color,
             shadow(3);
 
         &:backdrop {
         box-shadow:
+            // Intentionally not in ems since it's used as a stroke
             0 0 0 1px $toplevel-border-color,
             shadow(2);
         }


### PR DESCRIPTION
Adds an `em()` function that takes a size and converts it to ems. The second argument is a font-size if you have a different context and know you want a different font size to calculate from, otherwise it defaults to elementary defaults which is 9pt.

If you don't pass in a unit, it assumes `px`.