### PR TITLE
Add styles for modelbuttons

### DIFF
--- a/src/widgets/_popovers.scss
+++ b/src/widgets/_popovers.scss
@@ -10,8 +10,8 @@ popover {
         border: none;
         border-radius: 0;
         box-shadow: none;
-        min-width: 150px;
-        padding: 6px 12px;
+        min-width: em(150px);
+        padding: em(6px) em(12px);
 
         &:disabled {
             color: #{'@placeholder_text_color'};
@@ -28,12 +28,13 @@ popover {
 
         .keycap {
             background: rgba(0, 0, 0, 0.08);
-            border-radius: 3px;
+            border-radius: em(3px);
+            // Intentionally not in ems since it's used as a stroke
             box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15);
             color: #{'alpha(@fg_color, 0.78)'};
             font-size: 85%;
             margin: 0 0 1px;
-            min-width: 12px;
+            min-width: em(12px);
             // We trim off 1px on the bottom to account for box-shadow
             padding: 3px 6px 2px;
         }

--- a/src/widgets/_popovers.scss
+++ b/src/widgets/_popovers.scss
@@ -4,4 +4,38 @@ popover {
     border-radius: 6px;
     box-shadow: shadow(2);
     margin: 6px;
+
+    modelbutton {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+        box-shadow: none;
+        min-width: 150px;
+        padding: 6px 12px;
+
+        &:disabled {
+            color: #{'@placeholder_text_color'};
+
+            .keycap {
+                opacity: 0.7;
+            }
+        }
+
+        &:hover {
+            box-shadow: none;
+            background-color: #{'alpha(@fg_color, 0.15)'};
+        }
+
+        .keycap {
+            background: rgba(0, 0, 0, 0.08);
+            border-radius: 3px;
+            box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15);
+            color: #{'alpha(@fg_color, 0.78)'};
+            font-size: 85%;
+            margin: 0 0 1px;
+            min-width: 12px;
+            // We trim off 1px on the bottom to account for box-shadow
+            padding: 3px 6px 2px;
+        }
+    }
 }

--- a/src/widgets/_popovers.scss
+++ b/src/widgets/_popovers.scss
@@ -36,7 +36,7 @@ popover {
             margin: 0 0 1px;
             min-width: em(12px);
             // We trim off 1px on the bottom to account for box-shadow
-            padding: 3px 6px 2px;
+            padding: em(3px) em(6px) calc(#{em(3px)} - 1px);
         }
     }
 }

--- a/src/widgets/_popovers.scss
+++ b/src/widgets/_popovers.scss
@@ -10,8 +10,8 @@ popover {
         border: none;
         border-radius: 0;
         box-shadow: none;
-        min-width: em(150px);
-        padding: em(6px) em(12px);
+        min-width: rem(150px);
+        padding: rem(6px) rem(12px);
 
         &:disabled {
             color: #{'@placeholder_text_color'};
@@ -28,15 +28,15 @@ popover {
 
         .keycap {
             background: rgba(0, 0, 0, 0.08);
-            border-radius: em(3px);
+            border-radius: rem(3px);
             // Intentionally not in ems since it's used as a stroke
             box-shadow: 0 1px 0 0 rgba(0, 0, 0, 0.15);
             color: #{'alpha(@fg_color, 0.78)'};
             font-size: 85%;
             margin: 0 0 1px;
-            min-width: em(12px);
+            min-width: rem(12px);
             // We trim off 1px on the bottom to account for box-shadow
-            padding: em(3px) em(6px) calc(#{em(3px)} - 1px);
+            padding: rem(3px) rem(6px) calc(#{rem(3px)} - 1px);
         }
     }
 }


### PR DESCRIPTION
And keycaps in modelbuttons!

As seen in Granite Demo, but there are many modelbuttons in the panel and Terminal's menu uses one too