### PR TITLE
Slim up default-decoration titlebars

### DIFF
--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -11,7 +11,7 @@ dialog {
         }
     }
 
-    > headerbar.titlebar {
+    > .titlebar {
         border-radius: em(6px) em(6px) 0 0;
     }
 }
@@ -42,7 +42,7 @@ window:not(.popup) {
             // Intentionally not in ems since it's used as a stroke
             0 0 0 1px #{'alpha(shade(@color_primary, 0.7), 0.4)'},
             0 em(1px) em(2px) rgba(0, 0, 0, 0.2);
-        padding: 6px;
+        padding: em(6px);
 
         @if $color-scheme == "dark" {
             box-shadow:
@@ -57,6 +57,10 @@ window:not(.popup) {
                 outset-highlight("full"),
                 0 0 0 1px #{'alpha(shade(@color_primary, 0.7), 0.3)'},
                 0 em(1px) em(2px) rgba(0, 0, 0, 0.15);
+        }
+
+        &.default-decoration {
+	        padding: em(3px);
         }
 
 	    .title {


### PR DESCRIPTION
While we're here, use ems for padding and round the corners on all `.titlebar`, not just headerbars