### PR TITLE
Switches: Get rid of labels in GTK 3.22

### DIFF
--- a/src/widgets/_switches.scss
+++ b/src/widgets/_switches.scss
@@ -3,6 +3,7 @@ switch {
     border: 1px solid rgba(0, 0, 0, 0.2);
     box-shadow: inset-shadow();
     border-radius: rem(16px);
+    color: transparent; // Labels in GTK 3.22/Hera
     transition: all 200ms ease-in;
 
     &:checked:not(.mode-switch):not(:backdrop) {


### PR DESCRIPTION
So we had said we want to ignore styling for Hera, but this has been annoying me for screenshots and it’s just one line, with a comment. :shrug: