### PR TITLE
Experimental: Dark accent tint

### DIFF
--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -11,7 +11,7 @@ $fg-color: $BLACK_500;
 $toplevel-border-color: rgba(0, 0, 0, 0.2);
 
 @if $color-scheme == "dark" {
-    @define-color highlight_color #{'alpha(' + mix(white, $accent_color_100, 50%) + ', 0.3)'};
+    @define-color highlight_color #{'alpha(' + mix(white, $accent_color_100) + ', 0.2)'};
 
     $titlebar-color: mix(mix($BLACK_500, $BLACK_700, 70%), $accent_color_900, $weight: 99%);
 

--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -11,9 +11,9 @@ $fg-color: $BLACK_500;
 $toplevel-border-color: rgba(0, 0, 0, 0.2);
 
 @if $color-scheme == "dark" {
-    @define-color highlight_color rgba(255, 255, 255, 0.2);
+    @define-color highlight_color #{'alpha(' + mix(white, $accent_color_100, 50%) + ', 0.3)'};
 
-    $titlebar-color: mix($BLACK_500, $BLACK_700, $weight: 70%);
+    $titlebar-color: mix(mix($BLACK_500, $BLACK_700, 70%), $accent_color_900, $weight: 99%);
 
     $fg-color: #fff;
 
@@ -40,11 +40,11 @@ $toplevel-border-color: rgba(0, 0, 0, 0.2);
         }
     } @else if $color-scheme == "dark" {
         @if $level == 1 {
-            @return $BLACK_300;
+            @return mix($BLACK_300, $accent_color_900, 99%);
         } @else if $level == 2 {
-            @return $BLACK_500;
+            @return mix($BLACK_500, $accent_color_900, 99%);
         } @else if $level == 3 {
-            @return mix($BLACK_500, $BLACK_700, $weight: 75%);
+            @return mix(mix($BLACK_500, $BLACK_700, 75%), $accent_color_700, 99%);
         } @else if $level == 4 {
             @return $titlebar-color;
         }

--- a/src/_mixins.scss
+++ b/src/_mixins.scss
@@ -13,7 +13,7 @@ $toplevel-border-color: rgba(0, 0, 0, 0.2);
 @if $color-scheme == "dark" {
     @define-color highlight_color #{'alpha(' + mix(white, $accent_color_100) + ', 0.2)'};
 
-    $titlebar-color: mix(mix($BLACK_500, $BLACK_700, 70%), $accent_color_900, $weight: 99%);
+    $titlebar-color: mix(mix($BLACK_500, $BLACK_700, 70%), $accent_color_900, 99%);
 
     $fg-color: #fff;
 

--- a/src/variants/banana-dark.scss
+++ b/src/variants/banana-dark.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $BANANA_100;
+$accent_color_300: $BANANA_300;
+$accent_color_500: $BANANA_500;
+$accent_color_700: $BANANA_700;
+$accent_color_900: $BANANA_900;
+
+// Exported
 @define-color accent_color_100 @BANANA_100;
 @define-color accent_color_300 @BANANA_300;
 @define-color accent_color_500 @BANANA_500;

--- a/src/variants/banana.scss
+++ b/src/variants/banana.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $BANANA_100;
+$accent_color_300: $BANANA_300;
+$accent_color_500: $BANANA_500;
+$accent_color_700: $BANANA_700;
+$accent_color_900: $BANANA_900;
+
+// Exported
 @define-color accent_color_100 @BANANA_100;
 @define-color accent_color_300 @BANANA_300;
 @define-color accent_color_500 @BANANA_500;

--- a/src/variants/blueberry-dark.scss
+++ b/src/variants/blueberry-dark.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $BLUEBERRY_100;
+$accent_color_300: $BLUEBERRY_300;
+$accent_color_500: $BLUEBERRY_500;
+$accent_color_700: $BLUEBERRY_700;
+$accent_color_900: $BLUEBERRY_900;
+
+// Exported
 @define-color accent_color_100 @BLUEBERRY_100;
 @define-color accent_color_300 @BLUEBERRY_300;
 @define-color accent_color_500 @BLUEBERRY_500;

--- a/src/variants/blueberry.scss
+++ b/src/variants/blueberry.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $BLUEBERRY_100;
+$accent_color_300: $BLUEBERRY_300;
+$accent_color_500: $BLUEBERRY_500;
+$accent_color_700: $BLUEBERRY_700;
+$accent_color_900: $BLUEBERRY_900;
+
+// Exported
 @define-color accent_color_100 @BLUEBERRY_100;
 @define-color accent_color_300 @BLUEBERRY_300;
 @define-color accent_color_500 @BLUEBERRY_500;

--- a/src/variants/bubblegum-dark.scss
+++ b/src/variants/bubblegum-dark.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $BUBBLEGUM_100;
+$accent_color_300: $BUBBLEGUM_300;
+$accent_color_500: $BUBBLEGUM_500;
+$accent_color_700: $BUBBLEGUM_700;
+$accent_color_900: $BUBBLEGUM_900;
+
+// Exported
 @define-color accent_color_100 @BUBBLEGUM_100;
 @define-color accent_color_300 @BUBBLEGUM_300;
 @define-color accent_color_500 @BUBBLEGUM_500;

--- a/src/variants/bubblegum.scss
+++ b/src/variants/bubblegum.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $BUBBLEGUM_100;
+$accent_color_300: $BUBBLEGUM_300;
+$accent_color_500: $BUBBLEGUM_500;
+$accent_color_700: $BUBBLEGUM_700;
+$accent_color_900: $BUBBLEGUM_900;
+
+// Exported
 @define-color accent_color_100 @BUBBLEGUM_100;
 @define-color accent_color_300 @BUBBLEGUM_300;
 @define-color accent_color_500 @BUBBLEGUM_500;

--- a/src/variants/cocoa-dark.scss
+++ b/src/variants/cocoa-dark.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $COCOA_100;
+$accent_color_300: $COCOA_300;
+$accent_color_500: $COCOA_500;
+$accent_color_700: $COCOA_700;
+$accent_color_900: $COCOA_900;
+
+// Exported
 @define-color accent_color_100 @COCOA_100;
 @define-color accent_color_300 @COCOA_300;
 @define-color accent_color_500 @COCOA_500;

--- a/src/variants/cocoa.scss
+++ b/src/variants/cocoa.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $COCOA_100;
+$accent_color_300: $COCOA_300;
+$accent_color_500: $COCOA_500;
+$accent_color_700: $COCOA_700;
+$accent_color_900: $COCOA_900;
+
+// Exported
 @define-color accent_color_100 @COCOA_100;
 @define-color accent_color_300 @COCOA_300;
 @define-color accent_color_500 @COCOA_500;

--- a/src/variants/grape-dark.scss
+++ b/src/variants/grape-dark.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $GRAPE_100;
+$accent_color_300: $GRAPE_300;
+$accent_color_500: $GRAPE_500;
+$accent_color_700: $GRAPE_700;
+$accent_color_900: $GRAPE_900;
+
+// Exported
 @define-color accent_color_100 @GRAPE_100;
 @define-color accent_color_300 @GRAPE_300;
 @define-color accent_color_500 @GRAPE_500;

--- a/src/variants/grape.scss
+++ b/src/variants/grape.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $GRAPE_100;
+$accent_color_300: $GRAPE_300;
+$accent_color_500: $GRAPE_500;
+$accent_color_700: $GRAPE_700;
+$accent_color_900: $GRAPE_900;
+
+// Exported
 @define-color accent_color_100 @GRAPE_100;
 @define-color accent_color_300 @GRAPE_300;
 @define-color accent_color_500 @GRAPE_500;

--- a/src/variants/lime-dark.scss
+++ b/src/variants/lime-dark.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $LIME_100;
+$accent_color_300: $LIME_300;
+$accent_color_500: $LIME_500;
+$accent_color_700: $LIME_700;
+$accent_color_900: $LIME_900;
+
+// Exported
 @define-color accent_color_100 @LIME_100;
 @define-color accent_color_300 @LIME_300;
 @define-color accent_color_500 @LIME_500;

--- a/src/variants/lime.scss
+++ b/src/variants/lime.scss
@@ -19,7 +19,14 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $LIME_100;
+$accent_color_300: $LIME_300;
+$accent_color_500: $LIME_500;
+$accent_color_700: $LIME_700;
+$accent_color_900: $LIME_900;
+
+// Exported
 @define-color accent_color_100 @LIME_100;
 @define-color accent_color_300 @LIME_300;
 @define-color accent_color_500 @LIME_500;

--- a/src/variants/mint-dark.scss
+++ b/src/variants/mint-dark.scss
@@ -19,11 +19,19 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $MINT_100;
+$accent_color_300: $MINT_300;
+$accent_color_500: $MINT_500;
+$accent_color_700: $MINT_700;
+$accent_color_900: $MINT_900;
+
+// Exported
 @define-color accent_color_100 @MINT_100;
 @define-color accent_color_300 @MINT_300;
 @define-color accent_color_500 @MINT_500;
 @define-color accent_color_700 @MINT_700;
+@define-color accent_color_900 @MINT_900;
 @define-color accent_color_900 @MINT_900;
 
 $color-scheme: "dark";

--- a/src/variants/mint.scss
+++ b/src/variants/mint.scss
@@ -19,11 +19,19 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $MINT_100;
+$accent_color_300: $MINT_300;
+$accent_color_500: $MINT_500;
+$accent_color_700: $MINT_700;
+$accent_color_900: $MINT_900;
+
+// Exported
 @define-color accent_color_100 @MINT_100;
 @define-color accent_color_300 @MINT_300;
 @define-color accent_color_500 @MINT_500;
 @define-color accent_color_700 @MINT_700;
+@define-color accent_color_900 @MINT_900;
 @define-color accent_color_900 @MINT_900;
 
 $color-scheme: "light";

--- a/src/variants/orange-dark.scss
+++ b/src/variants/orange-dark.scss
@@ -19,11 +19,19 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $ORANGE_100;
+$accent_color_300: $ORANGE_300;
+$accent_color_500: $ORANGE_500;
+$accent_color_700: $ORANGE_700;
+$accent_color_900: $ORANGE_900;
+
+// Exported
 @define-color accent_color_100 @ORANGE_100;
 @define-color accent_color_300 @ORANGE_300;
 @define-color accent_color_500 @ORANGE_500;
 @define-color accent_color_700 @ORANGE_700;
+@define-color accent_color_900 @ORANGE_900;
 @define-color accent_color_900 @ORANGE_900;
 
 $color-scheme: "dark";

--- a/src/variants/orange.scss
+++ b/src/variants/orange.scss
@@ -19,11 +19,19 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $ORANGE_100;
+$accent_color_300: $ORANGE_300;
+$accent_color_500: $ORANGE_500;
+$accent_color_700: $ORANGE_700;
+$accent_color_900: $ORANGE_900;
+
+// Exported
 @define-color accent_color_100 @ORANGE_100;
 @define-color accent_color_300 @ORANGE_300;
 @define-color accent_color_500 @ORANGE_500;
 @define-color accent_color_700 @ORANGE_700;
+@define-color accent_color_900 @ORANGE_900;
 @define-color accent_color_900 @ORANGE_900;
 
 $color-scheme: "light";

--- a/src/variants/slate-dark.scss
+++ b/src/variants/slate-dark.scss
@@ -19,11 +19,19 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $SLATE_100;
+$accent_color_300: $SLATE_300;
+$accent_color_500: $SLATE_500;
+$accent_color_700: $SLATE_700;
+$accent_color_900: $SLATE_900;
+
+// Exported
 @define-color accent_color_100 @SLATE_100;
 @define-color accent_color_300 @SLATE_300;
 @define-color accent_color_500 @SLATE_500;
 @define-color accent_color_700 @SLATE_700;
+@define-color accent_color_900 @SLATE_900;
 @define-color accent_color_900 @SLATE_900;
 
 $color-scheme: "dark";

--- a/src/variants/slate.scss
+++ b/src/variants/slate.scss
@@ -19,11 +19,19 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $SLATE_100;
+$accent_color_300: $SLATE_300;
+$accent_color_500: $SLATE_500;
+$accent_color_700: $SLATE_700;
+$accent_color_900: $SLATE_900;
+
+// Exported
 @define-color accent_color_100 @SLATE_100;
 @define-color accent_color_300 @SLATE_300;
 @define-color accent_color_500 @SLATE_500;
 @define-color accent_color_700 @SLATE_700;
+@define-color accent_color_900 @SLATE_900;
 @define-color accent_color_900 @SLATE_900;
 
 $color-scheme: "light";

--- a/src/variants/strawberry-dark.scss
+++ b/src/variants/strawberry-dark.scss
@@ -19,11 +19,19 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $STRAWBERRY_100;
+$accent_color_300: $STRAWBERRY_300;
+$accent_color_500: $STRAWBERRY_500;
+$accent_color_700: $STRAWBERRY_700;
+$accent_color_900: $STRAWBERRY_900;
+
+// Exported
 @define-color accent_color_100 @STRAWBERRY_100;
 @define-color accent_color_300 @STRAWBERRY_300;
 @define-color accent_color_500 @STRAWBERRY_500;
 @define-color accent_color_700 @STRAWBERRY_700;
+@define-color accent_color_900 @STRAWBERRY_900;
 @define-color accent_color_900 @STRAWBERRY_900;
 
 $color-scheme: "dark";

--- a/src/variants/strawberry.scss
+++ b/src/variants/strawberry.scss
@@ -19,11 +19,19 @@
 
 @import '../_palette.scss';
 
-/* Accent Shades */
+// Internal, i.e. for tinting
+$accent_color_100: $STRAWBERRY_100;
+$accent_color_300: $STRAWBERRY_300;
+$accent_color_500: $STRAWBERRY_500;
+$accent_color_700: $STRAWBERRY_700;
+$accent_color_900: $STRAWBERRY_900;
+
+// Exported
 @define-color accent_color_100 @STRAWBERRY_100;
 @define-color accent_color_300 @STRAWBERRY_300;
 @define-color accent_color_500 @STRAWBERRY_500;
 @define-color accent_color_700 @STRAWBERRY_700;
+@define-color accent_color_900 @STRAWBERRY_900;
 @define-color accent_color_900 @STRAWBERRY_900;
 
 $color-scheme: "light";


### PR DESCRIPTION
Just seeing if we could tint the dark style with the accent color to bring that color subtly into more of the UI. Unsure how I feel about it, but it's kind of a neat effect. This mixes just 1% of the accent color's darkest shade into all dark bg levels, and 50% of the lightest shade into the highlight color. We could go less subtle, but I thought this was a good starting point.

To do so, I had to add sass variables for the accent colors. One drawback I see: this effect is not dynamic with application-set accent colors. The app would either need to request a (new, non-existent yet) neutral color scheme and then set its own accent, or be okay with the subtle user tint. The reason I could not use the GtkCSS variable is that we use the bg colors in other sass functions down the line.

I like the idea of an almost imperceptible tint for the dark style, but I don't know if the effect is worth the effort.

End result:

![Screenshot from 2020-05-10 14 14 24@2x](https://user-images.githubusercontent.com/611168/81509545-9d655600-92c8-11ea-9708-e95d0ddb36e8.png)


![Screenshot from 2020-05-10 14 14 29@2x](https://user-images.githubusercontent.com/611168/81509538-99393880-92c8-11ea-9390-d567e0185b5e.png)
