### PR TITLE
Typography: Set view foreground color

### DIFF
--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -1,4 +1,5 @@
-label {
+label,
+.view {
     color: #{'@fg_color'};
 }
 


### PR DESCRIPTION
I know we might want to do more styles for views, but this at least fixes #636 just by treating views like we do labels for now.