### PR TITLE
Add support for DazzleCompletionEntry

### DIFF
--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -18,6 +18,13 @@ messagedialog,
 @define-color success_color @LIME_700;
 @define-color warning_color @BANANA_900;
 
+// Things Dazzle expects
+@define-color borders #{"" + $toplevel-border-color};
+@define-color content_view_bg #{""+ bg_color(2)};
+@define-color theme_fg_color #{"" + $fg-color};
+@define-color theme_selected_fg_color #{"" + $fg-color};
+@define-color wm_shadow rgba(0, 0, 0, 0.2);
+
 selection {
     background-color: #{'alpha(@accent_color_100, 0.3)'};
     color: #{'@accent_color_900'};

--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -23,7 +23,7 @@ messagedialog,
 @define-color content_view_bg #{""+ bg_color(2)};
 @define-color theme_fg_color #{"" + $fg-color};
 @define-color theme_selected_fg_color #{"" + $fg-color};
-@define-color wm_shadow rgba(0, 0, 0, 0.2);
+@define-color wm_shadow #{rgba(black, 0.2)};
 
 selection {
     background-color: #{'alpha(@accent_color_100, 0.3)'};


### PR DESCRIPTION
Fixes #411 

It seems like Dazzle's built in styles take priority so we can't do any real styling, we can only add support for variables it expects.