### PR TITLE
Add basic notification styles

### DIFF
--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -61,6 +61,7 @@ selection {
 @import '_linked.scss';
 @import '_menus.scss';
 @import '_notebooks.scss';
+@import '_notifications.scss';
 @import '_panes.scss';
 @import '_popovers.scss';
 @import '_progressbars.scss';

--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -18,6 +18,13 @@ messagedialog,
 @define-color success_color @LIME_700;
 @define-color warning_color @BANANA_900;
 
+// Things Dazzle expects
+@define-color borders #{"" + $toplevel-border-color};
+@define-color content_view_bg #{""+ bg_color(2)};
+@define-color theme_fg_color #{"" + $fg-color};
+@define-color theme_selected_fg_color #{"" + $fg-color};
+@define-color wm_shadow #{rgba(black, 0.2)};
+
 selection {
     background-color: #{'alpha(@accent_color_100, 0.3)'};
     color: #{'@accent_color_900'};

--- a/src/widgets/_notifications.scss
+++ b/src/widgets/_notifications.scss
@@ -1,0 +1,39 @@
+.notification {
+    background-color: bg-color(2);
+    border-radius: rem(6px);
+    box-shadow:
+        outset-highlight(),
+        0 0 0 1px $toplevel-border-color,
+        shadow(3);
+
+    image {
+        color: rgba($fg-color, 0.78);
+    }
+
+    label.title {
+        font-weight: 700;
+    }
+
+    .urgent label.title {
+        color: #{'@error_color'};
+    }
+
+    progressbar {
+        progress,
+        trough {
+            box-shadow: none;
+            border: none;
+            border-radius: 6px;
+            margin: 0;
+        }
+
+        progress,
+        progress:backdrop {
+            background: rgba($fg-color, 0.78);
+        }
+
+        trough {
+            background: rgba($fg-color, 0.15);
+        }
+    }
+}

--- a/src/widgets/_notifications.scss
+++ b/src/widgets/_notifications.scss
@@ -23,7 +23,7 @@
         trough {
             box-shadow: none;
             border: none;
-            border-radius: 6px;
+            border-radius: rem(6px);
             margin: 0;
         }
 

--- a/src/widgets/_notifications.scss
+++ b/src/widgets/_notifications.scss
@@ -1,4 +1,4 @@
-.notification {
+window.notification .draw-area {
     background-color: bg-color(2);
     border-radius: rem(6px);
     box-shadow:


### PR DESCRIPTION
I'd like to do the styles for the notification window here to make sure that these shadows are kept consistent with other window types, especially if/when we differentiate between dark and light styles. These things aren't really exposed in the public API and so far there's no reason to expect they would be

Goes with: https://github.com/elementary/notifications/pull/79