### PR TITLE
Views: don't give viewport a bg

### DIFF
--- a/src/widgets/_views.scss
+++ b/src/widgets/_views.scss
@@ -14,8 +14,6 @@ scrolledwindow {
     }
 }
 
-
-viewport,
 .view {
     background-color: bg-color(1);
     color: $fg-color;


### PR DESCRIPTION
viewport should only have a background when it has `.view` class so that we can remove it if we need to