### PR TITLE
Window: square bottom corners

### DIFF
--- a/src/widgets/_sidebars.scss
+++ b/src/widgets/_sidebars.scss
@@ -2,7 +2,6 @@
     list {
         background-color: bg_color(3);
         padding-top: rem(6px);
-        border-bottom-left-radius: rem(6px);
 
         row {
             padding: rem(6px) rem(12px);

--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -1,9 +1,6 @@
 window.csd:not(.popup):not(.menu),
 dialog {
-    border-radius: 0 0 rem(6px) rem(6px);
-
     > decoration {
-        border-radius: rem(6px);
         margin: rem(12px);
     }
 
@@ -13,6 +10,10 @@ dialog {
 }
 
 window:not(.popup):not(.menu) {
+    decoration {
+        border-radius: rem(6px) 0 0;
+    }
+
     // We only draw shadows for client-side decorations
     &.csd {
         // Intentionally not in ems since it's used as a stroke
@@ -100,9 +101,11 @@ window:not(.popup):not(.menu) {
 }
 
 dialog {
+    border-radius: 0 0 rem(6px) rem(6px);
     box-shadow: outset-highlight("bottom");
 
     > decoration {
+        border-radius: rem(6px);
         box-shadow:
             // Intentionally not in ems since it's used as a stroke
             0 0 0 1px $toplevel-border-color,


### PR DESCRIPTION
We don't have window clipping in gtk3, so don't try to round window corners by default