### PR TITLE
Use `sassc` since `sass` is deprecated

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,16 +6,16 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
+
     container:
       image: elementary/docker:unstable
-    
+
     steps:
     - uses: actions/checkout@v1
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y meson sass
+        apt install -y meson sassc
     - name: Build
       env:
         DESTDIR: out

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A stylesheet for elementary OS
 
 You'll need the following dependencies:
 * meson
-* sass
+* sassc
 
 Run `meson` to configure the build environment. To install, use `ninja install`.
 

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
 )
 
 i18n = import('i18n')
-sass = find_program('sass')
+sass = find_program('sassc')
 
 install_exec = meson.current_source_dir() / 'meson' / 'install-to-dir.py'
 


### PR DESCRIPTION
Fixes #681 