### PR TITLE
Windows: only set decoration radius of immediate child

### DIFF
--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -10,7 +10,7 @@ dialog {
 }
 
 window:not(.popup):not(.menu) {
-    decoration {
+    > decoration {
         border-radius: rem(6px) rem(6px) 0 0;
     }
 


### PR DESCRIPTION
Fixes black squares under menu borders.

Since `menu decoration` is a child of `window`, it was being selected here