### PR TITLE
Toolbars: Add style for flat and inline actionbars

### DIFF
--- a/src/widgets/_toolbars.scss
+++ b/src/widgets/_toolbars.scss
@@ -1,4 +1,19 @@
-actionbar,
+actionbar {
+    background-color: bg-color(3);
+
+    &.flat,
+    &.inline-toolbar {
+        background-color: bg-color(2);
+        background-image:
+            linear-gradient(
+                to bottom,
+                rgba(black, 0.4),
+                rgba(black, 0.07) 1px,
+                transparent rem(3px)
+            );
+    }
+}
+
 .search-bar {
     background-color: bg-color(3);
 }


### PR DESCRIPTION
Fixes #587 

`.inline-toolbar` will be going away in Gtk4, so treat `.flat` as the same