### PR TITLE
Add third-party expected GTK color names

### DIFF
--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -26,6 +26,7 @@ messagedialog,
 @define-color wm_shadow #{rgba(black, 0.2)};
 
 // Things other apps expect
+@define-color base_color #{"" + bg_color(1)};
 @define-color theme_text_color #{'@text_color'};
 @define-color theme_bg_color #{'@bg_color'};
 @define-color theme_base_color #{'@base_color'};
@@ -43,8 +44,8 @@ messagedialog,
 //
 
 selection {
-    background-color: #{'alpha(@accent_color_100, 0.3)'};
-    color: #{'@accent_color_900'};
+    background-color: #{'@selected_bg_color'};
+    color: #{'@selected_fg_color'};
 }
 
 @if $color-scheme == "dark" {
@@ -53,8 +54,8 @@ selection {
     @define-color warning_color @BANANA_100;
 
     selection {
-        background-color: #{'alpha(@accent_color_700, 0.3)'};
-        color: #{'@accent_color_100'};
+        background-color: #{'@selected_bg_color'};
+        color: #{'@selected_fg_color'};
     }
 }
 

--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -25,6 +25,23 @@ messagedialog,
 @define-color theme_selected_fg_color #{"" + $fg-color};
 @define-color wm_shadow #{rgba(black, 0.2)};
 
+// Things other apps expect
+@define-color theme_text_color #{'@text_color'};
+@define-color theme_bg_color #{'@bg_color'};
+@define-color theme_base_color #{'@base_color'};
+@define-color selected_bg_color #{'alpha(@accent_color_100, 0.3)'};
+@define-color selected_fg_color #{'@accent_color_900'};
+@define-color theme_selected_bg_color #{'@selected_bg_color'};
+@define-color insensitive_fg_color #{'@insensitive_color'};
+
+@if $color-scheme == "dark" {
+    @define-color selected_bg_color #{'alpha(@accent_color_700, 0.3)'};
+    @define-color selected_fg_color #{'@accent_color_100'};
+    @define-color theme_selected_bg_color #{'@selected_bg_color'};
+    @define-color theme_selected_fg_color #{'@selected_fg_color'};
+}
+//
+
 selection {
     background-color: #{'alpha(@accent_color_100, 0.3)'};
     color: #{'@accent_color_900'};

--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -38,8 +38,6 @@ messagedialog,
 @if $color-scheme == "dark" {
     @define-color selected_bg_color #{'alpha(@accent_color_700, 0.3)'};
     @define-color selected_fg_color #{'@accent_color_100'};
-    @define-color theme_selected_bg_color #{'@selected_bg_color'};
-    @define-color theme_selected_fg_color #{'@selected_fg_color'};
 }
 //
 


### PR DESCRIPTION
These are seen in other apps than elementary's; adapted some to be different for dark style too.