### PR TITLE
Add basic List styles

### DIFF
--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -1,7 +1,3 @@
-label {
-    color: #{'@fg_color'};
-}
-
 .h1 {
     font-size: 24pt;
     letter-spacing: -0.04em;

--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -25,20 +25,21 @@ messagedialog,
 @define-color theme_selected_fg_color #{"" + $fg-color};
 @define-color wm_shadow #{rgba(black, 0.2)};
 
-selection {
-    background-color: #{'alpha(@accent_color_100, 0.3)'};
-    color: #{'@accent_color_900'};
-}
+@define-color selected_bg_color #{'alpha(@accent_color_100, 0.3)'};
+@define-color selected_fg_color #{'@accent_color_900'};
 
 @if $color-scheme == "dark" {
     @define-color error_color @STRAWBERRY_300;
     @define-color success_color @LIME_300;
     @define-color warning_color @BANANA_100;
 
-    selection {
-        background-color: #{'alpha(@accent_color_700, 0.3)'};
-        color: #{'@accent_color_100'};
-    }
+    @define-color selected_bg_color #{'alpha(@accent_color_700, 0.3)'};
+    @define-color selected_fg_color #{'@accent_color_100'};
+}
+
+selection {
+    background-color: #{'@selected_bg_color'};
+    color: #{'@selected_fg_color'};
 }
 
 .checkerboard {
@@ -87,6 +88,7 @@ selection {
 @import '_entries.scss';
 @import '_levelbars.scss';
 @import '_linked.scss';
+@import '_lists.scss';
 @import '_menus.scss';
 @import '_notebooks.scss';
 @import '_notifications.scss';

--- a/src/widgets/_lists.scss
+++ b/src/widgets/_lists.scss
@@ -7,7 +7,7 @@ list {
 
     row {
         &:selected {
-            background-color: rgba($fg-color, 0.2);
+            background-color: rgba($fg-color, 0.15);
 
             &:focus {
                 background-color: #{'@selected_bg_color'};

--- a/src/widgets/_lists.scss
+++ b/src/widgets/_lists.scss
@@ -18,5 +18,6 @@ list {
 
     .h4 {
         padding-left: rem(6px);
+        padding-right: rem(6px);
     }
 }

--- a/src/widgets/_lists.scss
+++ b/src/widgets/_lists.scss
@@ -7,7 +7,7 @@ list {
 
     row {
         &:selected {
-            background-color: rgba($fg-color, 0.15);
+            background-color: rgba($fg-color, 0.1);
 
             &:focus {
                 background-color: #{'@selected_bg_color'};

--- a/src/widgets/_lists.scss
+++ b/src/widgets/_lists.scss
@@ -1,0 +1,22 @@
+list {
+    background-color: bg-color(1);
+
+    popover & {
+        background-color: transparent;
+    }
+
+    row {
+        &:selected {
+            background-color: rgba($fg-color, 0.2);
+
+            &:focus {
+                background-color: #{'@selected_bg_color'};
+                color: #{'@selected_fg_color'};
+            }
+        }
+    }
+
+    .h4 {
+        padding-left: rem(6px);
+    }
+}

--- a/src/widgets/_sidebars.scss
+++ b/src/widgets/_sidebars.scss
@@ -16,6 +16,7 @@
 
             &:selected {
                 background-color: bg_color(4);
+                color: $fg-color;
             }
         }
     }


### PR DESCRIPTION
Copying the selection style here might end up being too light, but I wanted to try it

![Screenshot from 2020-05-26 11 39 52@2x](https://user-images.githubusercontent.com/7277719/82937807-a2233e80-9f45-11ea-82b9-aec2c39ba8af.png)

* Adds `selected_bg_color` and `selected_fg_color` public variables
* Re-add the padding rule for .h4 labels
* Removes the rule for `label` because this is too specific and it breaks styles such as in the datetime indicator and calendar. We should add `color` rules to containers, but probably not labels and images themselves
* Make sure that lists have a bg-color(1), unless they're in popovers. Almost always when we use a list in a popover we don't want it to have a background. If we do, we put it inside a frame with `view` class