### PR TITLE
Toolbars: Add styles for flat actionbars

### DIFF
--- a/src/widgets/_toolbars.scss
+++ b/src/widgets/_toolbars.scss
@@ -2,3 +2,15 @@ actionbar,
 .search-bar {
     background-color: bg-color(3);
 }
+
+actionbar.flat,
+actionbar.inline-toolbar {
+    background-color: bg-color(2);
+    background-image: linear-gradient(
+        to bottom,
+        $toplevel-border-color,
+        // Intentionally not in ems since it's used as a stroke
+        rgba(black, 0.12) 1px,
+        rgba(black, 0.0) rem(3px)
+    );
+}


### PR DESCRIPTION
Supports both `flat` and `inline-toolbar`. `Gtk.STYLE_CLASS_INLINE_TOOLBAR` is being removed from Gtk4, so we want to be able to start migrating over to `Gtk.STYLE_CLASS_FLAT`, but we probably also want to keep "legacy" support