### PR TITLE
Separator fixes

### DIFF
--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -16,6 +16,7 @@ messagedialog,
 
 // Separator color
 @define-color menu_separator #{rgba(black, 0.15)};
+@define-color menu_separator_shadow #{rgba(white, 0.8)};
 
 @define-color error_color @STRAWBERRY_500;
 @define-color success_color @LIME_700;
@@ -36,7 +37,8 @@ messagedialog,
     @define-color success_color @LIME_300;
     @define-color warning_color @BANANA_100;
 
-    @define-color menu_separator rgba(black, 0.25);
+    @define-color menu_separator #{rgba(black, 0.25)};
+    @define-color menu_separator_shadow #{rgba(white, 0.05)};
 
     @define-color selected_bg_color #{'alpha(@accent_color_700, 0.3)'};
     @define-color selected_fg_color #{'@accent_color_100'};

--- a/src/widgets/_menus.scss
+++ b/src/widgets/_menus.scss
@@ -2,20 +2,6 @@
     background-color: bg_color(2);
     border-radius: rem(6px);
     color: $fg-color;
-
-    separator {
-        min-height: rem(6px);
-
-        &.horizontal {
-            border-top: 1px solid #{'@menu_separator'};
-            margin-bottom: -1px;
-        }
-
-        &.vertical {
-            border-left: 1px solid #{'@menu_separator'};
-            margin-right: -1px;
-        }
-    }
 }
 
 %menuitem {
@@ -129,5 +115,11 @@ window.popup {
     menuitem,
     .menuitem {
         @extend %menuitem;
+    }
+
+    separator {
+        border-top: 1px solid #{'@menu_separator'};
+        border-bottom: 1px solid #{'@menu_separator_shadow'};
+        margin: rem(3px) 0;
     }
 }

--- a/src/widgets/_popovers.scss
+++ b/src/widgets/_popovers.scss
@@ -15,6 +15,20 @@ popover {
         margin: -4px -10px;
     }
 
+    separator {
+        &.horizontal {
+            border-top: 1px solid #{'@menu_separator'};
+            border-bottom: 1px solid #{'@menu_separator_shadow'};
+            margin-bottom: -1px;
+        }
+
+        &.vertical {
+            border-left: 1px solid #{'@menu_separator'};
+            border-right: 1px solid #{'@menu_separator_shadow'};
+            margin-right: -1px;
+        }
+    }
+
     undershoot {
         &.top {
             background:


### PR DESCRIPTION
* Add highlights to separators
* Menu separators can only be horizontal and never get the `horizontal` class. This fixes them being unstyled
* Popover separators sometimes want 0 margin because they butt up against scrolled windows, so we only apply margin to menu separators where we know we're working with a simpler set of widgets. We use margin, not min-height/width because borders are on the outside of the box