### PR TITLE
Define accent color in variant

### DIFF
--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -27,29 +27,7 @@ label.h4,
 }
 
 .accent {
-    color: #{'@accent_color_700'};
-
-    // Special-case especially light or dark palette colors
-    @if $accent-name == "cocoa" or
-        $accent-name == "slate" {
-        color: #{'@accent_color_500'};
-    } @else if $accent-name == "banana" or
-        $accent-name == "lime" {
-        color: #{'mix(@accent_color_700, @accent_color_900, 0.5)'};
-    }
-
-    @if $color-scheme == "dark" {
-        color: #{'mix(@accent_color_300, @accent_color_500, 0.5)'};
-
-        @if $accent-name == "banana" {
-            color: #{'@accent_color_500'};
-        } @else if $accent-name == "strawberry" {
-            color: #{'@accent_color_300'};
-        } @else if $accent-name == "cocoa" or
-            $accent-name == "slate" {
-            color: #{'mix(@accent_color_100, @accent_color_300, 0.5)'};
-        }
-    }
+    color: #{'@accent_color'};
 }
 
 .dim-label {

--- a/src/variants/banana-dark.scss
+++ b/src/variants/banana-dark.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @BANANA_700;
 @define-color accent_color_900 @BANANA_900;
 
-$accent-name: "banana";
+@define-color accent_color @BANANA_500;
+
 $color-scheme: "dark";
 
 @import '../_mixins.scss';

--- a/src/variants/banana.scss
+++ b/src/variants/banana.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @BANANA_700;
 @define-color accent_color_900 @BANANA_900;
 
-$accent-name: "banana";
+@define-color accent_color #{'mix(@accent_color_700, @accent_color_900, 0.5)'};
+
 $color-scheme: "light";
 
 @import '../_mixins.scss';

--- a/src/variants/blueberry-dark.scss
+++ b/src/variants/blueberry-dark.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @BLUEBERRY_700;
 @define-color accent_color_900 @BLUEBERRY_900;
 
-$accent-name: "blueberry";
+@define-color accent_color #{'mix(@accent_color_300, @accent_color_500, 0.5)'};
+
 $color-scheme: "dark";
 
 @import '../_mixins.scss';

--- a/src/variants/blueberry.scss
+++ b/src/variants/blueberry.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @BLUEBERRY_700;
 @define-color accent_color_900 @BLUEBERRY_900;
 
-$accent-name: "blueberry";
+@define-color accent_color @BLUEBERRY_700;
+
 $color-scheme: "light";
 
 @import '../_mixins.scss';

--- a/src/variants/bubblegum-dark.scss
+++ b/src/variants/bubblegum-dark.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @BUBBLEGUM_700;
 @define-color accent_color_900 @BUBBLEGUM_900;
 
-$accent-name: "bubblegum";
+@define-color accent_color #{'mix(@accent_color_300, @accent_color_500, 0.5)'};
+
 $color-scheme: "dark";
 
 @import '../_mixins.scss';

--- a/src/variants/bubblegum.scss
+++ b/src/variants/bubblegum.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @BUBBLEGUM_700;
 @define-color accent_color_900 @BUBBLEGUM_900;
 
-$accent-name: "bubblegum";
+@define-color accent_color @BUBBLEGUM_700;
+
 $color-scheme: "light";
 
 @import '../_mixins.scss';

--- a/src/variants/cocoa-dark.scss
+++ b/src/variants/cocoa-dark.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @COCOA_700;
 @define-color accent_color_900 @COCOA_900;
 
-$accent-name: "cocoa";
+@define-color accent_color #{'mix(@accent_color_100, @accent_color_300, 0.5)'};
+
 $color-scheme: "dark";
 
 @import '../_mixins.scss';

--- a/src/variants/cocoa.scss
+++ b/src/variants/cocoa.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @COCOA_700;
 @define-color accent_color_900 @COCOA_900;
 
-$accent-name: "cocoa";
+@define-color accent_color @COCOA_500;
+
 $color-scheme: "light";
 
 @import '../_mixins.scss';

--- a/src/variants/grape-dark.scss
+++ b/src/variants/grape-dark.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @GRAPE_700;
 @define-color accent_color_900 @GRAPE_900;
 
-$accent-name: "grape";
+@define-color accent_color #{'mix(@accent_color_300, @accent_color_500, 0.5)'};
+
 $color-scheme: "dark";
 
 @import '../_mixins.scss';

--- a/src/variants/grape.scss
+++ b/src/variants/grape.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @GRAPE_700;
 @define-color accent_color_900 @GRAPE_900;
 
-$accent-name: "grape";
+@define-color accent_color @GRAPE_700;
+
 $color-scheme: "light";
 
 @import '../_mixins.scss';

--- a/src/variants/lime-dark.scss
+++ b/src/variants/lime-dark.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @LIME_700;
 @define-color accent_color_900 @LIME_900;
 
-$accent-name: "lime";
+@define-color accent_color #{'mix(@accent_color_300, @accent_color_500, 0.5)'};
+
 $color-scheme: "dark";
 
 @import '../_mixins.scss';

--- a/src/variants/lime.scss
+++ b/src/variants/lime.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @LIME_700;
 @define-color accent_color_900 @LIME_900;
 
-$accent-name: "lime";
+@define-color accent_color #{'mix(@accent_color_700, @accent_color_900, 0.5)'};
+
 $color-scheme: "light";
 
 @import '../_mixins.scss';

--- a/src/variants/mint-dark.scss
+++ b/src/variants/mint-dark.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @MINT_700;
 @define-color accent_color_900 @MINT_900;
 
-$accent-name: "mint";
+@define-color accent_color #{'mix(@accent_color_300, @accent_color_500, 0.5)'};
+
 $color-scheme: "dark";
 
 @import '../_mixins.scss';

--- a/src/variants/mint.scss
+++ b/src/variants/mint.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @MINT_700;
 @define-color accent_color_900 @MINT_900;
 
-$accent-name: "mint";
+@define-color accent_color @MINT_700;
+
 $color-scheme: "light";
 
 @import '../_mixins.scss';

--- a/src/variants/orange-dark.scss
+++ b/src/variants/orange-dark.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @ORANGE_700;
 @define-color accent_color_900 @ORANGE_900;
 
-$accent-name: "orange";
+@define-color accent_color #{'mix(@accent_color_300, @accent_color_500, 0.5)'};
+
 $color-scheme: "dark";
 
 @import '../_mixins.scss';

--- a/src/variants/orange.scss
+++ b/src/variants/orange.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @ORANGE_700;
 @define-color accent_color_900 @ORANGE_900;
 
-$accent-name: "orange";
+@define-color accent_color @ORANGE_700;
+
 $color-scheme: "light";
 
 @import '../_mixins.scss';

--- a/src/variants/slate-dark.scss
+++ b/src/variants/slate-dark.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @SLATE_700;
 @define-color accent_color_900 @SLATE_900;
 
-$accent-name: "slate";
+@define-color accent_color #{'mix(@accent_color_100, @accent_color_300, 0.5)'};;
+
 $color-scheme: "dark";
 
 @import '../_mixins.scss';

--- a/src/variants/slate.scss
+++ b/src/variants/slate.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @SLATE_700;
 @define-color accent_color_900 @SLATE_900;
 
-$accent-name: "slate";
+@define-color accent_color @SLATE_500;
+
 $color-scheme: "light";
 
 @import '../_mixins.scss';

--- a/src/variants/strawberry-dark.scss
+++ b/src/variants/strawberry-dark.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @STRAWBERRY_700;
 @define-color accent_color_900 @STRAWBERRY_900;
 
-$accent-name: "strawberry";
+@define-color accent_color @STRAWBERRY_300;
+
 $color-scheme: "dark";
 
 @import '../_mixins.scss';

--- a/src/variants/strawberry.scss
+++ b/src/variants/strawberry.scss
@@ -26,7 +26,8 @@
 @define-color accent_color_700 @STRAWBERRY_700;
 @define-color accent_color_900 @STRAWBERRY_900;
 
-$accent-name: "strawberry";
+@define-color accent_color @STRAWBERRY_700;
+
 $color-scheme: "light";
 
 @import '../_mixins.scss';


### PR DESCRIPTION
The previous method breaks apps who want to set their own accent color.

We also rely on a single accent color variable in apps like Calendar and Tasks to be able to override easily.

This should preserve our special calculations for contrasty accent colors while having only one easily overridden accent color variable