### PR TITLE
Typography: bold dialog titles

### DIFF
--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -22,7 +22,7 @@ label.h4,
 }
 
 .primary {
-    font-weight: 500;
+    font-weight: 800;
     font-size: 1.22em
 }
 

--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -22,7 +22,7 @@ label.h4,
 }
 
 .primary {
-    font-weight: 800;
+    font-weight: 700;
     font-size: 1.22em
 }
 


### PR DESCRIPTION
Opening for discussion/consideration. I love this style, but also feel like the bolder titles more effectively balance out both the icon and the action buttons. It also makes it a bit easier to skim the gist of the dialog at a glance.

## 700 weight

![Screenshot from 2020-06-30 15 04 12@2x](https://user-images.githubusercontent.com/611168/86177253-89c5b700-bae3-11ea-8dba-b0a52c03301b.png)

![Screenshot from 2020-06-30 15 05 15@2x](https://user-images.githubusercontent.com/611168/86177276-94804c00-bae3-11ea-96a9-c796c4524c68.png)

![Screenshot from 2020-06-30 15 07 41@2x](https://user-images.githubusercontent.com/611168/86177283-977b3c80-bae3-11ea-846f-20fb3d177592.png)

![Screenshot from 2020-06-30 15 07 14@2x](https://user-images.githubusercontent.com/611168/86177290-9a762d00-bae3-11ea-8b24-df2ed76c35e7.png)

## 800 weight

![inter-800](https://user-images.githubusercontent.com/611168/83296405-f6305c00-a1ad-11ea-8a5e-ef25ebe9d083.png)

![Screenshot from 2020-05-29 12 51 27@2x](https://user-images.githubusercontent.com/611168/83296365-e6b11300-a1ad-11ea-80a8-10d4dbbdee5e.png)

![Screenshot from 2020-05-29 12 50 30@2x](https://user-images.githubusercontent.com/611168/83296395-f16ba800-a1ad-11ea-87a3-ef829b3eef26.png)

![Screenshot from 2020-05-29 12 54 54@2x](https://user-images.githubusercontent.com/611168/83296380-ea449a00-a1ad-11ea-9513-6fffbaacd227.png)

## master

![inter-500](https://user-images.githubusercontent.com/611168/83296495-20821980-a1ae-11ea-8ec6-1dab31e950af.png)

![Screenshot from 2020-05-29 12 57 25@2x](https://user-images.githubusercontent.com/611168/83296507-25df6400-a1ae-11ea-9a23-c0940a7ad847.png)

![Screenshot from 2020-05-29 12 56 43@2x](https://user-images.githubusercontent.com/611168/83296531-2ed03580-a1ae-11ea-9f86-29ee2c8106a9.png)

![Screenshot from 2020-05-29 12 55 52@2x](https://user-images.githubusercontent.com/611168/83296589-40b1d880-a1ae-11ea-8f05-d9838d315dd0.png)
