### PR TITLE
Move exported GtkCSS variables to their own file

### DIFF
--- a/src/_exported.scss
+++ b/src/_exported.scss
@@ -19,9 +19,9 @@
 @define-color placeholder_text_color #{"" + mix($fg-color, bg-color(1), $weight: 75%)};
 
 // Semantic colors
-@define-color error_color $error-color;
-@define-color success_color $success-color;
-@define-color warning_color $warning-color;
+@define-color error_color #{"" + $error-color};
+@define-color success_color #{"" + $success-color};
+@define-color warning_color #{"" + $warning-color};
 
 @define-color menu_separator #{rgba(black, 0.15)};
 

--- a/src/_exported.scss
+++ b/src/_exported.scss
@@ -32,7 +32,8 @@
 @define-color borders #{"" + $toplevel-border-color};
 @define-color content_view_bg #{""+ bg_color(2)};
 @define-color theme_fg_color #{"" + $fg-color};
-@define-color theme_selected_fg_color #{"" + $fg-color};
+@define-color theme_selected_bg_color #{'@selected_bg_color'};
+@define-color theme_selected_fg_color #{'@selected_fg_color'};
 @define-color wm_shadow #{rgba(black, 0.2)};
 
 @if $color-scheme == "dark" {

--- a/src/_exported.scss
+++ b/src/_exported.scss
@@ -1,0 +1,43 @@
+// These are defined as GtkCSS variables, so are accessible and overridable
+// inside of apps. While internal sass variables are considered private API,
+// these exported GtkCSS variables should be considered public API.
+
+// Inset box shadows
+@define-color highlight_color white;
+
+@if $color-scheme == "dark" {
+    @define-color highlight_color #{"" + rgba(white, 0.2)};
+}
+
+// The primary brand color used for titlebars
+@define-color color_primary #{$titlebar-color};
+
+// Text and image color
+@define-color fg_color #{"" + $fg-color};
+
+// Placeholder text in entries. Doesn't respect alpha
+@define-color placeholder_text_color #{"" + mix($fg-color, bg-color(1), $weight: 75%)};
+
+// Semantic colors
+@define-color error_color $error-color;
+@define-color success_color $success-color;
+@define-color warning_color $warning-color;
+
+@define-color menu_separator #{rgba(black, 0.15)};
+
+@define-color selected_bg_color #{'alpha(@accent_color_100, 0.3)'};
+@define-color selected_fg_color #{'@accent_color_900'};
+
+// Things Dazzle expects
+@define-color borders #{"" + $toplevel-border-color};
+@define-color content_view_bg #{""+ bg_color(2)};
+@define-color theme_fg_color #{"" + $fg-color};
+@define-color theme_selected_fg_color #{"" + $fg-color};
+@define-color wm_shadow #{rgba(black, 0.2)};
+
+@if $color-scheme == "dark" {
+    @define-color menu_separator rgba(black, 0.25);
+
+    @define-color selected_bg_color #{'alpha(@accent_color_700, 0.3)'};
+    @define-color selected_fg_color #{'@accent_color_100'};
+}

--- a/src/_index.scss
+++ b/src/_index.scss
@@ -16,7 +16,6 @@ $warning_color: $BANANA_900;
     $titlebar-color: mix($BLACK_500, $BLACK_700, $weight: 70%);
     $fg-color: white;
     $toplevel-border-color: rgba(black, 0.75);
-}
 
     $error-color: $STRAWBERRY_300;
     $success-color: $LIME_300;

--- a/src/_index.scss
+++ b/src/_index.scss
@@ -1,6 +1,3 @@
-// Inset box shadows
-@define-color highlight_color white;
-
 // The default titlebar color
 $titlebar-color: mix($SILVER_100, $SILVER_300, $weight: 30%);
 
@@ -10,18 +7,20 @@ $fg-color: $BLACK_500;
 // Outset box shadow or border color on toplevel elements like windows, menus, popovers
 $toplevel-border-color: rgba(black, 0.2);
 
+// Semantic colors
+$error_color: $STRAWBERRY_500;
+$success_color: $LIME_700;
+$warning_color: $BANANA_900;
+
 @if $color-scheme == "dark" {
-    @define-color highlight_color #{"" + rgba(white, 0.2)};
-
     $titlebar-color: mix($BLACK_500, $BLACK_700, $weight: 70%);
-
     $fg-color: white;
-
     $toplevel-border-color: rgba(black, 0.6);
-}
 
-// The primary brand color used for titlebars
-@define-color color_primary #{$titlebar-color};
+    $error-color: $STRAWBERRY_300;
+    $success-color: $LIME_300;
+    $warning-color: $BANANA_100;
+}
 
 @function bg-color($level) {
     @if $color-scheme == "light" {
@@ -193,6 +192,7 @@ $toplevel-border-color: rgba(black, 0.2);
 }
 
 @import '_animate.scss';
+@import '_exported.scss';
 @import '_typography.scss';
 // Can't just use `@import 'widgets';` because of sass version in repos
 @import 'widgets/_index.scss';

--- a/src/variants/banana-dark.scss
+++ b/src/variants/banana-dark.scss
@@ -29,4 +29,5 @@
 $accent-name: "banana";
 $color-scheme: "dark";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/banana.scss
+++ b/src/variants/banana.scss
@@ -29,4 +29,5 @@
 $accent-name: "banana";
 $color-scheme: "light";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/blueberry-dark.scss
+++ b/src/variants/blueberry-dark.scss
@@ -29,4 +29,5 @@
 $accent-name: "blueberry";
 $color-scheme: "dark";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/blueberry.scss
+++ b/src/variants/blueberry.scss
@@ -29,4 +29,5 @@
 $accent-name: "blueberry";
 $color-scheme: "light";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/bubblegum-dark.scss
+++ b/src/variants/bubblegum-dark.scss
@@ -29,4 +29,5 @@
 $accent-name: "bubblegum";
 $color-scheme: "dark";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/bubblegum.scss
+++ b/src/variants/bubblegum.scss
@@ -29,4 +29,5 @@
 $accent-name: "bubblegum";
 $color-scheme: "light";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/cocoa-dark.scss
+++ b/src/variants/cocoa-dark.scss
@@ -29,4 +29,5 @@
 $accent-name: "cocoa";
 $color-scheme: "dark";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/cocoa.scss
+++ b/src/variants/cocoa.scss
@@ -29,4 +29,5 @@
 $accent-name: "cocoa";
 $color-scheme: "light";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/grape-dark.scss
+++ b/src/variants/grape-dark.scss
@@ -29,4 +29,5 @@
 $accent-name: "grape";
 $color-scheme: "dark";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/grape.scss
+++ b/src/variants/grape.scss
@@ -29,4 +29,5 @@
 $accent-name: "grape";
 $color-scheme: "light";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/lime-dark.scss
+++ b/src/variants/lime-dark.scss
@@ -29,4 +29,5 @@
 $accent-name: "lime";
 $color-scheme: "dark";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/lime.scss
+++ b/src/variants/lime.scss
@@ -29,4 +29,5 @@
 $accent-name: "lime";
 $color-scheme: "light";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/mint-dark.scss
+++ b/src/variants/mint-dark.scss
@@ -29,4 +29,5 @@
 $accent-name: "mint";
 $color-scheme: "dark";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/mint.scss
+++ b/src/variants/mint.scss
@@ -29,4 +29,5 @@
 $accent-name: "mint";
 $color-scheme: "light";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/orange-dark.scss
+++ b/src/variants/orange-dark.scss
@@ -29,4 +29,5 @@
 $accent-name: "orange";
 $color-scheme: "dark";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/orange.scss
+++ b/src/variants/orange.scss
@@ -29,4 +29,5 @@
 $accent-name: "orange";
 $color-scheme: "light";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/slate-dark.scss
+++ b/src/variants/slate-dark.scss
@@ -29,4 +29,5 @@
 $accent-name: "slate";
 $color-scheme: "dark";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/slate.scss
+++ b/src/variants/slate.scss
@@ -29,4 +29,5 @@
 $accent-name: "slate";
 $color-scheme: "light";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/strawberry-dark.scss
+++ b/src/variants/strawberry-dark.scss
@@ -29,4 +29,5 @@
 $accent-name: "strawberry";
 $color-scheme: "dark";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/variants/strawberry.scss
+++ b/src/variants/strawberry.scss
@@ -29,4 +29,5 @@
 $accent-name: "strawberry";
 $color-scheme: "light";
 
-@import '../_mixins.scss';
+// Can't just use `@import '../';` because of sass version in repos
+@import '../index.scss';

--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -51,6 +51,40 @@ button {
             }
         }
 
+        &.destructive-action:not(:disabled) {
+            $accent-fg-color: #{'mix (black, @accent_color_900, 0.8)'};
+            $bg-color: #{'@accent_color_100'};
+            $border-color: #{'alpha (mix (black, @accent_color_300, 0.8), 0.4)'};
+            $checked-border-color: alpha #{'(@accent_color_500, 0.45)'};
+
+            @if $color-scheme == "light" {
+                background-clip: border-box;
+                box-shadow:
+                    outset-highlight("full"),
+                    0 1px 1px rgba(black, 0.07),
+                    0 1px 2px rgba(black, 0.2);
+            } @else if $color-scheme == "dark" {
+                $accent-fg-color: white;
+                $bg-color: #{'mix (black, @accent_color_300, 0.5)'};
+                $border-color: #{'alpha (@accent_color_900, 0.5)'};
+                $checked-border-color: rgba(black, 0.5);
+            }
+
+            background-color: $bg-color;
+            border-color: $border-color;
+
+            image,
+            label {
+                color: $accent-fg-color;
+            }
+
+            &:active,
+            &:checked {
+                background-color: $bg-color;
+                border-color: $checked-border-color;
+            }
+        }
+
         &.titlebutton:not(:active) {
             background: none;
             border-color: transparent;

--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -51,40 +51,6 @@ button {
             }
         }
 
-        &.destructive-action:not(:disabled) {
-            $accent-fg-color: #{'mix (black, @accent_color_900, 0.8)'};
-            $bg-color: #{'@accent_color_100'};
-            $border-color: #{'alpha (mix (black, @accent_color_300, 0.8), 0.4)'};
-            $checked-border-color: alpha #{'(@accent_color_500, 0.45)'};
-
-            @if $color-scheme == "light" {
-                background-clip: border-box;
-                box-shadow:
-                    outset-highlight("full"),
-                    0 1px 1px rgba(black, 0.07),
-                    0 1px 2px rgba(black, 0.2);
-            } @else if $color-scheme == "dark" {
-                $accent-fg-color: white;
-                $bg-color: #{'mix (black, @accent_color_300, 0.5)'};
-                $border-color: #{'alpha (@accent_color_900, 0.5)'};
-                $checked-border-color: rgba(black, 0.5);
-            }
-
-            background-color: $bg-color;
-            border-color: $border-color;
-
-            image,
-            label {
-                color: $accent-fg-color;
-            }
-
-            &:active,
-            &:checked {
-                background-color: $bg-color;
-                border-color: $checked-border-color;
-            }
-        }
-
         &.titlebutton:not(:active) {
             background: none;
             border-color: transparent;

--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -8,40 +8,6 @@ messagedialog,
     color: $fg-color;
 }
 
-// Text and image color
-@define-color fg_color #{"" + $fg-color};
-
-// Placeholder text in entries. Doesn't respect alpha
-@define-color placeholder_text_color #{"" + mix($fg-color, bg-color(1), $weight: 75%)};
-
-// Separator color
-@define-color menu_separator #{rgba(black, 0.15)};
-
-@define-color error_color @STRAWBERRY_500;
-@define-color success_color @LIME_700;
-@define-color warning_color @BANANA_900;
-
-// Things Dazzle expects
-@define-color borders #{"" + $toplevel-border-color};
-@define-color content_view_bg #{""+ bg_color(2)};
-@define-color theme_fg_color #{"" + $fg-color};
-@define-color theme_selected_fg_color #{"" + $fg-color};
-@define-color wm_shadow #{rgba(black, 0.2)};
-
-@define-color selected_bg_color #{'alpha(@accent_color_100, 0.3)'};
-@define-color selected_fg_color #{'@accent_color_900'};
-
-@if $color-scheme == "dark" {
-    @define-color error_color @STRAWBERRY_300;
-    @define-color success_color @LIME_300;
-    @define-color warning_color @BANANA_100;
-
-    @define-color menu_separator rgba(black, 0.25);
-
-    @define-color selected_bg_color #{'alpha(@accent_color_700, 0.3)'};
-    @define-color selected_fg_color #{'@accent_color_100'};
-}
-
 selection {
     background-color: #{'@selected_bg_color'};
     color: #{'@selected_fg_color'};


### PR DESCRIPTION
Was from my work in https://github.com/elementary/stylesheet/compare/destructive, but pulled out. Supersedes #735 I guess. Only focuses on GtkCSS variables to keep it clear what is external vs internal API.

- Creates new `_exported.scss` file with only exported GtkCSS variables. Things that Dazzle, GTK apps, and apps using foreign drawing APIs might expect. The closest thing GTK has to a theming API.
- Renames `_mixins.scss` to `_index.css` since we're using it for variable definitions, placeholder classes, mixins, and anything else that doesn't have a better home yet.