### PR TITLE
Style destructive-action buttons

### DIFF
--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -27,6 +27,17 @@ button {
             outset-highlight("full"),
             outset-shadow(2);
 
+        &.destructive-action:not(:disabled) {
+            @if $color-scheme == "light" {
+                background-clip: border-box;
+            }
+
+            background-color: $STRAWBERRY_500;
+            color: white;
+            text-shadow: 0 1px 1px $STRAWBERRY_500;
+            -gtk-icon-shadow: 0 1px 1px $STRAWBERRY_500;
+        }
+
         &.suggested-action:not(:disabled) {
             $accent-fg-color: #{'mix (black, @accent_color_900, 0.8)'};
             $bg-color: #{'@accent_color_100'};

--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -30,6 +30,11 @@ button {
         &.destructive-action:not(:disabled) {
             @if $color-scheme == "light" {
                 background-clip: border-box;
+            } @else if $color-scheme == "dark" {
+                &:active,
+                &:checked {
+                    border-color: rgba(black, 0.7);
+                }
             }
 
             background-color: $STRAWBERRY_500;


### PR DESCRIPTION
Fixes #496 
Fixes #589 

I just spent like 20 minutes trying to figure out why the toggle button in gtk3-widget-factory was losing the color when `:checked` and it turns out that they remove `.destructive-action` when it's toggled 😑️