### PR TITLE
Button: Add spacing between images and labels

### DIFF
--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -100,4 +100,9 @@ button {
     label {
         font-weight: 500;
     }
+
+    &:dir(ltr) image + label,
+    &:dir(rtl) label + image {
+        margin-left: rem(3px);
+    }
 }


### PR DESCRIPTION
When a button contains both an image and a label, make sure we add column spacing