### PR TITLE
Notebook Tabs: move padding to grid

### DIFF
--- a/src/widgets/_notebooks.scss
+++ b/src/widgets/_notebooks.scss
@@ -27,7 +27,6 @@ tab {
     margin: rem(3px) 0;
     // Not scaled because it's based on icon size
     min-width: 24px;
-    padding: rem(3px);
 
     &:hover:not(:checked) {
         background-color: bg-color(4);
@@ -43,5 +42,9 @@ tab {
         &:backdrop {
             background-color: bg-color(2);
         }
+    }
+
+    > widget > grid {
+        padding: rem(3px);
     }
 }


### PR DESCRIPTION
Fixes #523

Currently there is a padding around the `Granite.Widgets.Tab`. So clicks within the 3px edge of the tab are not registered and instead ripple through to the `Granite.DynamicNotebook`. This can lead to the problem, that when trying to close a tab with <kbd>Middle</kbd>  or <kbd>Three-Finger</kbd><kbd>Click</kbd> an old tab is restored instead.

**Before** (EventArea of `GraniteWidgetsTab` )
![tab-before](https://user-images.githubusercontent.com/24651767/87238139-21d67100-c3ff-11ea-9fe1-cf4a3a31c158.png)

**After** (EventArea of `GraniteWidgetsTab` )
![tab-after](https://user-images.githubusercontent.com/24651767/87238140-24d16180-c3ff-11ea-8521-1d386bf9b46b.png)

