### PR TITLE
Titles & Subtitles

### DIFF
--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -70,13 +70,3 @@ label.h4,
 :link:hover label {
   text-decoration: underline;
 }
-
-.titlebar .title {
-    font-size: 9pt;
-    font-weight: bold;
-}
-
-.subtitle {
-    opacity: 0.75;
-    font-size: 85%;
-}

--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -70,3 +70,13 @@ label.h4,
 :link:hover label {
   text-decoration: underline;
 }
+
+.titlebar .title {
+    font-size: 9pt;
+    font-weight: bold;
+}
+
+.subtitle {
+    opacity: 0.75;
+    font-size: 85%;
+}

--- a/src/widgets/_toolbars.scss
+++ b/src/widgets/_toolbars.scss
@@ -15,6 +15,11 @@ actionbar {
     &.flat{
         @extend .inline-toolbar;
     }
+    &.title {
+        font-size: 11pt;
+        font-weight: bold;
+        padding: 0 12px;
+    }
 }
 
 .search-bar {

--- a/src/widgets/_toolbars.scss
+++ b/src/widgets/_toolbars.scss
@@ -15,9 +15,15 @@ actionbar {
     &.flat{
         @extend .inline-toolbar;
     }
+
     &.title {
         font-size: 11pt;
         font-weight: bold;
+        padding: 0 12px;
+    }
+
+    &.subtitle {
+        font-size: 9pt;
         padding: 0 12px;
     }
 }

--- a/src/widgets/_toolbars.scss
+++ b/src/widgets/_toolbars.scss
@@ -19,7 +19,7 @@ actionbar {
     &.title {
         font-size: 11pt;
         font-weight: 600;
-        padding: 0 12px;
+        padding: 0 rem(12px);
     }
 
     &.subtitle {

--- a/src/widgets/_toolbars.scss
+++ b/src/widgets/_toolbars.scss
@@ -15,17 +15,6 @@ actionbar {
     &.flat{
         @extend .inline-toolbar;
     }
-
-    &.title {
-        font-size: 11pt;
-        font-weight: 600;
-        padding: 0 rem(12px);
-    }
-
-    &.subtitle {
-        font-size: 9pt;
-        padding: 0 rem(12px);
-    }
 }
 
 .search-bar {

--- a/src/widgets/_toolbars.scss
+++ b/src/widgets/_toolbars.scss
@@ -24,7 +24,7 @@ actionbar {
 
     &.subtitle {
         font-size: 9pt;
-        padding: 0 12px;
+        padding: 0 rem(12px);
     }
 }
 

--- a/src/widgets/_toolbars.scss
+++ b/src/widgets/_toolbars.scss
@@ -18,7 +18,7 @@ actionbar {
 
     &.title {
         font-size: 11pt;
-        font-weight: bold;
+        font-weight: 600;
         padding: 0 12px;
     }
 

--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -177,7 +177,7 @@ window:not(.popup):not(.menu) {
 
         .subtitle {
             opacity: 0.75;
-            font-size: 85%;
+            font-size: 80%;
         }
 
         .titlebutton,

--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -203,7 +203,6 @@ window:not(.popup):not(.menu) {
         background-color: #{"@color_primary"};
 
         .title {
-            font-size: 9pt;
             font-weight: 600;
             text-shadow: $shadow
         }

--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -170,8 +170,14 @@ window:not(.popup):not(.menu) {
         background-color: #{"@color_primary"};
 
         .title {
+            font-size: 9pt;
             font-weight: 600;
             text-shadow: $shadow
+        }
+
+        .subtitle {
+            opacity: 0.75;
+            font-size: 85%;
         }
 
         .titlebutton,

--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -212,6 +212,8 @@ dialog {
         box-shadow: outset-highlight("top");
 
         label.title {
+            text-shadow: none;
+            -gtk-icon-shadow: none;
             font-size: 0.1px; // Workaround for an issue in Gtk when setting 0px
             color: transparent;
         }


### PR DESCRIPTION
Porting over missing title and subtitle styling, while also updating it for the new stylesheet.

Looks like this:
![Screenshot from 2020-07-12 23 05 44](https://user-images.githubusercontent.com/4886639/87263663-44ff3000-c494-11ea-9ccf-fbbac17003a6.png)