### PR TITLE
Menus: Only apply image and check styles to menu menuitem

### DIFF
--- a/src/widgets/_menus.scss
+++ b/src/widgets/_menus.scss
@@ -60,36 +60,6 @@
             -gtk-icon-source: -gtk-icontheme("pan-start-symbolic");
         }
     }
-
-    &:dir(ltr) {
-        image:first-child {
-            // Off-by-one for some reason. Maybe optical illusion?
-            margin-left: rem(-23px);
-            padding-left: 0;
-            padding-right: rem(5px);
-        }
-
-        > check,
-        > radio {
-            margin-right: rem(6px);
-            margin-left: rem(-6px);
-        }
-    }
-
-    &:dir(rtl) {
-        image:first-child {
-            // Off-by-one for some reason. Maybe optical illusion?
-            margin-right: rem(-23px);
-            padding-left: rem(5px);
-            padding-right: 0;
-        }
-
-        > check,
-        > radio {
-            margin-left: rem(6px);
-            margin-right: rem(-6px);
-        }
-    }
 }
 
 menu,
@@ -120,6 +90,36 @@ window.popup {
     menuitem,
     .menuitem {
         @extend %menuitem;
+
+        &:dir(ltr) {
+            image:first-child {
+                // Off-by-one for some reason. Maybe optical illusion?
+                margin-left: rem(-23px);
+                padding-left: 0;
+                padding-right: rem(5px);
+            }
+
+            > check,
+            > radio {
+                margin-right: rem(6px);
+                margin-left: rem(-6px);
+            }
+        }
+
+        &:dir(rtl) {
+            image:first-child {
+                // Off-by-one for some reason. Maybe optical illusion?
+                margin-right: rem(-23px);
+                padding-left: rem(5px);
+                padding-right: 0;
+            }
+
+            > check,
+            > radio {
+                margin-left: rem(6px);
+                margin-right: rem(-6px);
+            }
+        }
     }
 
     separator {


### PR DESCRIPTION
These styles are for checkmenuitem and image menu items in menus, but they do fucky things to layouts in popovers like in the bluetooth menu