### PR TITLE
Add a bg level for inputs

### DIFF
--- a/src/_index.scss
+++ b/src/_index.scss
@@ -24,8 +24,11 @@ $warning_color: $BANANA_900;
 
 @function bg-color($level) {
     @if $color-scheme == "light" {
-        // Views and inputs
-        @if $level == 1 {
+        // Inputs
+        @if $level == 0 {
+            @return $SILVER_100;
+        // Views
+        } @else if $level == 1 {
             @return white;
         // Background
         } @else if $level == 2 {
@@ -38,8 +41,10 @@ $warning_color: $BANANA_900;
             @return $titlebar-color;
         }
     } @else if $color-scheme == "dark" {
-        @if $level == 1 {
-            @return $BLACK_300;
+        @if $level == 0 {
+            @return mix($BLACK_300, $BLACK_500, $weight: 50%);
+        } @else if $level == 1 {
+            @return mix($BLACK_300, $BLACK_500, $weight: 25%);
         } @else if $level == 2 {
             @return $BLACK_500;
         } @else if $level == 3 {

--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -21,8 +21,14 @@ button {
     &.raised.image-button,
     & {
         @extend %outset-background;
-        background-color: bg-color(2);
-        border: 1px solid rgba(black, 0.2);
+
+        $border-color: rgba(black, 0.2);
+        @if $color-scheme == "dark" {
+            $border-color: rgba(black, 0.3);
+        }
+
+        background-color: bg-color(0);
+        border: 1px solid $border-color;
         box-shadow:
             outset-highlight("full"),
             outset-shadow(2);

--- a/src/widgets/_checkbuttons.scss
+++ b/src/widgets/_checkbuttons.scss
@@ -6,7 +6,7 @@ radio {
     }
 
     @extend %outset-background;
-    background-color: bg-color(1);
+    background-color: bg-color(0);
     border: 1px solid $border-color;
     box-shadow:
         outset-highlight(),

--- a/src/widgets/_levelbars.scss
+++ b/src/widgets/_levelbars.scss
@@ -2,7 +2,7 @@ levelbar {
     block {
         $border-color: rgba(black, 0.2);
         @if $color-scheme == "dark" {
-            $border-color: rgba(black, 0.5);
+            $border-color: rgba(black, 0.4);
         }
 
         background-color: #{'@accent_color_300'};
@@ -12,6 +12,10 @@ levelbar {
             outset-highlight(),
             outset-shadow(1);
         transition: all duration("element") $easing;
+
+        @if $color-scheme == "dark" {
+            background-clip: padding-box;
+        }
 
         &.filled {
             &.low {
@@ -36,7 +40,7 @@ levelbar {
         }
 
         &.empty {
-            background-color: bg-color(1);
+            background-color: bg-color(0);
         }
     }
 

--- a/src/widgets/_progressbars.scss
+++ b/src/widgets/_progressbars.scss
@@ -1,7 +1,7 @@
 progressbar {
     $border-color: rgba(black, 0.2);
     @if $color-scheme == "dark" {
-        $border-color: rgba(black, 0.5);
+        $border-color: rgba(black, 0.4);
     }
 
     border-radius: rem(2px);
@@ -26,7 +26,7 @@ progressbar {
     }
 
     trough {
-        background-color: bg-color(1);
+        background-color: bg-color(0);
         box-shadow:
             outset-highlight(),
             outset-shadow(1);

--- a/src/widgets/_scales.scss
+++ b/src/widgets/_scales.scss
@@ -17,7 +17,7 @@ scale {
 
     slider {
         @extend %outset-background;
-        background-color: bg-color(2);
+        background-color: bg-color(0);
         border-radius: rem(12px);
         box-shadow:
             outset-highlight(),

--- a/src/widgets/_switches.scss
+++ b/src/widgets/_switches.scss
@@ -29,7 +29,7 @@ switch {
 
     slider {
         @extend %outset-background;
-        background-color: bg-color(2);
+        background-color: bg-color(0);
         background-clip: padding-box;
         border-radius: 50%;
         box-shadow:


### PR DESCRIPTION
Supersedes #780 
Fixes #671 

Introduces a new bg level 0 for inputs. This is used for buttons, switch handles, sliders, checkboxes, etc

## BEFORE
![Screenshot from 2020-09-03 13 24 14@2x](https://user-images.githubusercontent.com/7277719/92163720-00837700-ede9-11ea-9734-17770ae3cf64.png)

## AFTER
![Screenshot from 2020-09-03 13 21 16@2x](https://user-images.githubusercontent.com/7277719/92163741-07aa8500-ede9-11ea-83d6-d8c98525a328.png)

This also darkens the view color which makes apps like Files not so ugly:

## BEFORE
![Screenshot from 2020-09-03 13 28 23@2x](https://user-images.githubusercontent.com/7277719/92163949-5f48f080-ede9-11ea-90b2-da6e8e91b051.png)

## AFTER
![Screenshot from 2020-09-03 13 27 51@2x](https://user-images.githubusercontent.com/7277719/92163959-63750e00-ede9-11ea-8546-13bb1b5864f3.png)


You'll also notice no significant impact on the light style:

![Screenshot from 2020-09-03 13 26 48@2x](https://user-images.githubusercontent.com/7277719/92163832-2c9ef800-ede9-11ea-9ae8-682ec781c6b9.png)
![Screenshot from 2020-09-03 13 26 22@2x](https://user-images.githubusercontent.com/7277719/92163841-2f99e880-ede9-11ea-9acc-f217a8889e90.png)

