### PR TITLE
CheckButtons: Fix image color in dark radiobuttons

### DIFF
--- a/src/widgets/_checkbuttons.scss
+++ b/src/widgets/_checkbuttons.scss
@@ -84,7 +84,7 @@ radiobutton.image-button {
     padding: rem(6px);
 
     &:checked:not(:backdrop) image {
-        color: #{'@accent_color_700'};
+        color: #{'@accent_color'};
     }
 }
 


### PR DESCRIPTION
Fixes #808 

![Screenshot from 2020-09-11 11 24 18@2x](https://user-images.githubusercontent.com/7277719/92959861-6b543400-f421-11ea-9bbd-81fe128cb52c.png)
