### PR TITLE
Remove separators from StackSidebar

### DIFF
--- a/src/widgets/_separators.scss
+++ b/src/widgets/_separators.scss
@@ -18,6 +18,10 @@ separator {
         margin: 0 rem(18px);
     }
 
+    stacksidebar &.horizontal {
+        border: none;
+    }
+
     &.titlebutton {
         border: none;
         margin: 0 rem(3px);

--- a/src/widgets/_sidebars.scss
+++ b/src/widgets/_sidebars.scss
@@ -37,10 +37,6 @@
     }
 }
 
-stacksidebar separator {
-    border: none;
-}
-
 treeview.sidebar {
     -GtkTreeView-horizontal-separator: 1px;
     -GtkTreeView-vertical-separator: 6px;

--- a/src/widgets/_sidebars.scss
+++ b/src/widgets/_sidebars.scss
@@ -37,6 +37,10 @@
     }
 }
 
+stacksidebar separator {
+    border: none;
+}
+
 treeview.sidebar {
     -GtkTreeView-horizontal-separator: 1px;
     -GtkTreeView-vertical-separator: 6px;


### PR DESCRIPTION
As seen in GraniteDemo. I don't want seps in my stacksidebar