### PR TITLE
Typography: lower contrast of accent labels

### DIFF
--- a/src/_typography.scss
+++ b/src/_typography.scss
@@ -31,9 +31,9 @@ label.h4,
 .link,
 :link {
     @if $color-scheme == "light" {
-        color: #{'shade(@accent_color, 0.6)'};
+        color: #{'shade(@accent_color, 0.75)'};
     } @else if $color-scheme == "dark" {
-        color: #{'mix(@accent_color, white, 0.33)'};
+        color: #{'mix(@accent_color, white, 0.1)'};
     }
 }
 

--- a/src/variants/banana-dark.scss
+++ b/src/variants/banana-dark.scss
@@ -26,7 +26,7 @@
 @define-color accent_color_700 @BANANA_700;
 @define-color accent_color_900 @BANANA_900;
 
-@define-color accent_color mix(@BANANA_500, @BANANA_700, 0.25);
+@define-color accent_color mix(@BANANA_500, @BANANA_700, 0.5);
 
 $color-scheme: "dark";
 

--- a/src/variants/banana.scss
+++ b/src/variants/banana.scss
@@ -26,7 +26,7 @@
 @define-color accent_color_700 @BANANA_700;
 @define-color accent_color_900 @BANANA_900;
 
-@define-color accent_color @BANANA_500;
+@define-color accent_color mix(@BANANA_500, @BANANA_700, 0.3);
 
 $color-scheme: "light";
 


### PR DESCRIPTION
Makes accent color transforms way less aggressive. In apps like Tasks, getting to AA with every color (yellow in light, red in dark) was requiring really aggressive transforms to where you could barely even tell what color certain ones were supposed to be (like mint).

I think it's okay to settle for A grade contrast with accent labels since they'll likely be either large bold primary text or used for icons or something other than normal body labels