### PR TITLE
Show selection and focus in Grids and Lists

### DIFF
--- a/src/widgets/_lists.scss
+++ b/src/widgets/_lists.scss
@@ -6,13 +6,13 @@ list {
     }
 
     row {
+        &:focus,
         &:selected {
-            background-color: rgba($fg-color, 0.1);
+            background: rgba($fg-color, 0.15);
+        }
 
-            &:focus {
-                background-color: #{'@selected_bg_color'};
-                color: #{'@selected_fg_color'};
-            }
+        &:focus:selected {
+            @extend selection;
         }
     }
 

--- a/src/widgets/_treeviews.scss
+++ b/src/widgets/_treeviews.scss
@@ -1,18 +1,30 @@
-treeview header button {
-    border-left-width: 0;
-    border-radius: 0;
-    border-top-width: 0;
+treeview {
+    &.view.cell {
+        &:selected {
+            background: rgba($fg-color, 0.15);
+        }
 
-    &:last-child {
-        border-right-width: 0;
+        &:focus:selected {
+            @extend selection;
+        }
     }
 
-    label {
-        font-weight: 600;
-        opacity: 0.8;
-    }
+    header button {
+        border-left-width: 0;
+        border-radius: 0;
+        border-top-width: 0;
 
-    &:backdrop label {
-        opacity: 0.6;
+        &:last-child {
+            border-right-width: 0;
+        }
+
+        label {
+            font-weight: 600;
+            opacity: 0.8;
+        }
+
+        &:backdrop label {
+            opacity: 0.6;
+        }
     }
 }

--- a/src/widgets/_views.scss
+++ b/src/widgets/_views.scss
@@ -7,6 +7,27 @@ frame,
     }
 }
 
+iconview.view.cell {
+    border-radius: rem(3px);
+
+    &:selected {
+        background: rgba($fg-color, 0.15);
+    }
+}
+
+flowboxchild {
+    border-radius: rem(3px);
+
+    &:focus,
+    &:selected {
+        background: rgba($fg-color, 0.15);
+    }
+
+    &:focus:selected {
+        @extend selection;
+    }
+}
+
 scrolledwindow {
     // avoid double borders when viewport inside scrolled window
     > viewport.frame {

--- a/src/widgets/_views.scss
+++ b/src/widgets/_views.scss
@@ -13,6 +13,10 @@ iconview.view.cell {
     &:selected {
         background: rgba($fg-color, 0.15);
     }
+
+    &:focus:selected {
+        @extend selection;
+    }
 }
 
 flowboxchild {


### PR DESCRIPTION
Fixes #781 

Yo dawg I heard you like to get around with a keyboard

Shows focus and selection in flowboxes, listboxes, icon views, and treeviews such as in:
* Files
* System Settings
* Music
* Videos
* And More!

Does not work for the applications menu because that is a bunch of buttons in a grid. Gross