### PR TITLE
Fix paned separator

### DIFF
--- a/elementary/gtk-3.0/gtk-widgets.css
+++ b/elementary/gtk-3.0/gtk-widgets.css
@@ -216,26 +216,28 @@ paned.vertical > separator {
     background-image:
         linear-gradient(
             to bottom,
-            @menu_separator 1px,
+            @menu_separator 9px,
             @menu_separator_shadow 1px,
             @menu_separator_shadow 2px,
             transparent 2px
         );
-    margin-bottom: -7px;
-    min-height: 8px;
+    margin-top: -4px;
+    margin-bottom: -4px;
+    min-height: 9px;
 }
 
 paned.horizontal > separator {
     background-image:
         linear-gradient(
             to right,
-            @menu_separator 1px,
+            @menu_separator 9px,
             @menu_separator_shadow 1px,
             @menu_separator_shadow 2px,
             transparent 2px
         );
-    margin-right: -7px;
-    min-width: 8px;
+    margin-left: -4px;
+    margin-right: -4px;
+    min-width: 9px;
 }
 
 paned > separator.wide {


### PR DESCRIPTION
Currently the course only appears on the separator and 8 pixels after the separator.
The correction makes the cursor appear 4 pixels before and 4 pixels after.

This fix issue [573](https://github.com/elementary/stylesheet/issues/573) 