### PR TITLE
Windows: Remove box shadow on .unified .flat.titlebar

### DIFF
--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -183,6 +183,10 @@ window:not(.popup):not(.menu) {
                 0 0 0 1px #{'alpha(shade(@color_primary, 0.7), 0.4)'},
                 0 rem(1px) rem(2px) rgba(black, 0.2);
 
+            &.flat {
+                box-shadow: none;
+            }
+
             @if $color-scheme == "dark" {
                 box-shadow:
                     outset-highlight("bottom"),


### PR DESCRIPTION
Fixes a funny extra dark shadow line in the separators in Tasks (and other apps)

We don't need any box shadow at all here because the window border is set on the unified window and the inset highlight is done on the overlay node