### PR TITLE
Sidebar: Remove list top padding

### DIFF
--- a/src/widgets/_sidebars.scss
+++ b/src/widgets/_sidebars.scss
@@ -26,14 +26,10 @@
 }
 
 .sidebar {
-    list {
-        padding-top: rem(6px);
+    list row {
+        padding: rem(6px) rem(12px);
 
-        row {
-            padding: rem(6px) rem(12px);
-
-            @extend %sidebar-row;
-        }
+        @extend %sidebar-row;
     }
 }
 


### PR DESCRIPTION
I was trying to be too clever here. This messes up padding in the new Files listbox sidebar