### PR TITLE
Entries: Set minimum height to accomodate icons

### DIFF
--- a/src/widgets/_entries.scss
+++ b/src/widgets/_entries.scss
@@ -26,6 +26,8 @@
 
 entry {
     @extend %entry;
+    // Prevent size change when setting primary or secondary icons
+    min-height: 16px;
     // Off-by-one to account for padding-box clip
     padding: rem(4px);
 


### PR DESCRIPTION
This prevents a resize jump when adding icons to entries such as in User Accounts when creating a new user