### PR TITLE
Spinners: spin discretely

### DIFF
--- a/src/widgets/_spinners.scss
+++ b/src/widgets/_spinners.scss
@@ -5,7 +5,7 @@ spinner {
 
     &:checked {
         opacity: 0.8;
-        animation: spin 600ms linear infinite;
+        animation: spin 600ms steps(12) infinite;
 
         &:disabled {
             opacity: 0.4;


### PR DESCRIPTION
Our spinner icon is designed for a discrete 12-frame spin, but we're currently smoothly animating the whole spin. This PR sets the animation-timing-function for spinners specifically to take 12 steps, also matching the new BGRT plymouth theme.

This is hard to capture in a GIF because of framerate, but here's an attempt; notice in the "after" GIF the spokes stay in the correct orientation.

Before | After
---|---
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/611168/101089663-b4c0a500-3572-11eb-8381-b306992eb7c2.gif) | ![ezgif com-video-to-gif(1)](https://user-images.githubusercontent.com/611168/101089676-ba1def80-3572-11eb-8b8b-d4cf16b0df56.gif)




