### PR TITLE
Fix editable treeview cell background color

### DIFF
--- a/src/widgets/_sidebars.scss
+++ b/src/widgets/_sidebars.scss
@@ -40,4 +40,9 @@ treeview.sidebar {
     .view {
         @extend %sidebar-row;
     }
+
+    entry.flat {
+        // to match row selection
+        background-color: bg_color(4);
+    }
 }

--- a/src/widgets/_treeviews.scss
+++ b/src/widgets/_treeviews.scss
@@ -9,6 +9,12 @@ treeview {
         }
     }
 
+    entry.flat {
+        // Account for some off-by-one funkiness
+        padding: rem(4px) rem(1px);
+        background: inherit;
+    }
+
     header button {
         border-left-width: 0;
         border-radius: 0;


### PR DESCRIPTION
Fixes #896 

We can't use transparent backgrounds here in treeview because I guess the widgets are stacked