### PR TITLE
Dim backdrop buttons

### DIFF
--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -145,6 +145,10 @@ button {
         color: $insensitive-fg-color;
     }
 
+    :backdrop & {
+        opacity: 0.75;
+    }
+
     &.color,
     &.combo,
     &.image-button,


### PR DESCRIPTION
This might not be the best approach, but currently, headerbars only change their color a bit when in backdrop, and accent-colored widgets drop their accent color. However, this leaves apps with headerbars and content in a more ambigous state.

This PR dims buttons in the backdrop state to make it even more clear which app is focused. There are probably lots of other small backdrop improvements we could do, but this might be a good step.

Feedback welcome.