### PR TITLE
Windows: don't set negative margin in dialogs

### DIFF
--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -272,11 +272,6 @@ messagedialog {
         }
     }
 
-    .dialog-vbox {
-        // Remove the 2px border_width from Gtk.Dialog. Intentionally not in ems
-        margin: -2px;
-    }
-
     // These should should in 12px borders around buttons
     .dialog-action-area {
         // Compensate for off-by-one


### PR DESCRIPTION
This is a bad hack and it's causing issues in FileChooser dialogs