### PR TITLE
Sidebars: Get rid of extra frames in GtkPlacesSidebar

### DIFF
--- a/src/widgets/_sidebars.scss
+++ b/src/widgets/_sidebars.scss
@@ -33,6 +33,11 @@
     }
 }
 
+placessidebar.frame,
+placessidebar viewport.frame {
+    border: none;
+}
+
 treeview.sidebar {
     -GtkTreeView-horizontal-separator: 1px;
     -GtkTreeView-vertical-separator: 6px;


### PR DESCRIPTION
Gets rid of multiple extra frames in file chooser dialogs