### PR TITLE
Experiment: Icon Dropshadow CSS class

### DIFF
--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -35,9 +35,9 @@ selection {
 .icon-dropshadow {
     // Used for adding shadow to icons programmatically and not manually,
     // mimics the most used shadow type in icons.
-    -gtk-icon-shadow: 0 4px 3px rgba(black, 0.0),
-                      0 4px 2px rgba(black, 0.12),
-                      0 4px 1px rgba(black, 0.0);
+    -gtk-icon-shadow: 0 1px 1px transparent,
+                      0 2px 2px rgba(black, 0.2),
+                      0 3px 3px transparent;
 }
 
 .error {

--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -32,6 +32,14 @@ selection {
     -gtk-outline-radius: 9999px;
 }
 
+.icon-dropshadow {
+    // Used for adding shadow to icons programmatically and not manually,
+    // mimics the most used shadow type in icons.
+    -gtk-icon-shadow: 0 4px 3px rgba(black, 0.0),
+                      0 4px 2px rgba(black, 0.12),
+                      0 4px 1px rgba(black, 0.0);
+}
+
 .error {
     color: #{'@error_color'};
 }


### PR DESCRIPTION
The class `.icon-dropshadow` adds the same shadow as the one made manually following the guidelines,
but automatically, so nobody would need to make the shadow themselves in Inkscape anymore.

The catch, is that one would need to add the class targetting the `Gtk.Image` holding the icons.

Looks like this:
![result](https://user-images.githubusercontent.com/4886639/104393569-847e0600-5523-11eb-8e54-d1c5bd85229e.png)

P.S. If the icons above look bad in their shadow, it's due to the manually added shadow plus the css class' shadow
on top of each other. Check the Icon Previewer icon for the intended effect.