### PR TITLE
Windows: Only apply action area double space to messagedialog

### DIFF
--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -277,7 +277,10 @@ messagedialog {
         // Compensate for off-by-one
         margin: rem(7px);
         margin-bottom: rem(8px);
-        // Double space between content and actions
-        margin-top: rem(16px);
     }
+}
+
+messagedialog .dialog-action-area {
+    // Double space between content and actions
+    margin-top: rem(16px);
 }

--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -7,6 +7,7 @@
 assistant,
 dialog,
 messagedialog,
+message-dialog,
 printdialog,
 window.csd:not(.popup):not(.menu) {
     > decoration {
@@ -237,7 +238,8 @@ window:not(.popup):not(.menu) {
 }
 
 dialog,
-messagedialog {
+messagedialog,
+message-dialog {
     border-radius: 0 0 rem(6px) rem(6px);
     box-shadow: outset-highlight("bottom");
 
@@ -280,7 +282,8 @@ messagedialog {
     }
 }
 
-messagedialog .dialog-action-area {
+messagedialog .dialog-action-area,
+message-dialog .dialog-action-area {
     // Double space between content and actions
     margin-top: rem(16px);
 }


### PR DESCRIPTION
This fixes the incorrect extra spacing in, for example, file chooser dialogs

requires https://github.com/elementary/granite/pull/462