### PR TITLE
Windows: only round CSD dialogs

### DIFF
--- a/src/widgets/_windows.scss
+++ b/src/widgets/_windows.scss
@@ -245,7 +245,6 @@ window:not(.popup):not(.menu) {
 dialog,
 messagedialog,
 message-dialog {
-    border-radius: 0 0 rem(6px) rem(6px);
     box-shadow: outset-highlight("bottom");
 
     > decoration {
@@ -267,16 +266,20 @@ message-dialog {
         }
     }
 
-    > .titlebar {
-        background-color: bg_color(2);
-        box-shadow: outset-highlight("top");
+    &.csd {
+        border-radius: 0 0 rem(6px) rem(6px);
 
-        label.title {
-            text-shadow: none;
-            -gtk-icon-shadow: none;
-            font-size: 0.1px; // Workaround for an issue in Gtk when setting 0px
-            color: transparent;
-        }
+       > .titlebar {
+           background-color: bg_color(2);
+           box-shadow: outset-highlight("top");
+
+           label.title {
+               text-shadow: none;
+               -gtk-icon-shadow: none;
+               font-size: 0.1px; // Workaround for an issue in Gtk when setting 0px
+               color: transparent;
+           }
+       }
     }
 
     // These should should in 12px borders around buttons


### PR DESCRIPTION
Fixes #944 

And titlebar styles only apply to CSD