### PR TITLE
Sidebar Dark: Set bg_color(2) on selected item

### DIFF
--- a/src/widgets/_sidebars.scss
+++ b/src/widgets/_sidebars.scss
@@ -12,6 +12,9 @@
     &.highlight {
         background-color: bg_color(4);
         color: $fg-color;
+        @if $color-scheme == "dark" {
+            background-color: bg_color(2);
+        }
     }
 }
 


### PR DESCRIPTION
Selected item on sidebar dark style not visible well because bg-color were set on 4 for dark and light style. Only for dark style are setted on 2, one point of distance of the background color `bg_color(3)` like light style.
This fix #822 