### PR TITLE
Exported: Add unfocused_borders

### DIFF
--- a/src/_exported.scss
+++ b/src/_exported.scss
@@ -40,6 +40,7 @@
 
 // Outset box shadow or border color on toplevel elements like windows, menus, popovers
 @define-color borders #{"" + $toplevel-border-color};
+@define-color unfocused_borders #{"" + $toplevel-border-color};
 
 @define-color bg_color #{"" + bg_color(2)};
 @define-color theme_bg_color #{""+ bg_color(2)};


### PR DESCRIPTION
Another towards #734 

We don't change border colors on backdrop, so this is purely for the benefit of Adwaita-expecting apps