### PR TITLE
Add and use unfocused selected colors

### DIFF
--- a/src/_exported.scss
+++ b/src/_exported.scss
@@ -26,6 +26,8 @@
 
 @define-color selected_bg_color #{'alpha(@accent_color, 0.25)'};
 @define-color selected_fg_color #{'shade(@accent_color, 0.5)'};
+@define-color theme_unfocused_selected_bg_color #{'alpha(@text_color, 0.10)'};
+@define-color theme_unfocused_selected_fg_color #{"" + $fg-color};
 
 @if $color-scheme == "dark" {
     @define-color menu_separator #{rgba(black, 0.25)};

--- a/src/widgets/_index.scss
+++ b/src/widgets/_index.scss
@@ -5,6 +5,11 @@ image:disabled {
 selection {
     background-color: #{'@selected_bg_color'};
     color: #{'@selected_fg_color'};
+
+    &:backdrop {
+        background-color: #{'@theme_unfocused_selected_bg_color'};
+        color: #{'@theme_unfocused_selected_fg_color'};
+    }
 }
 
 .checkerboard {


### PR DESCRIPTION
Fixes #734 

text selections now lose color in backdrop. Gtk widget factory is probably one of the easiest ways to test this