### PR TITLE
Further define and use insensitive base color

### DIFF
--- a/src/_exported.scss
+++ b/src/_exported.scss
@@ -41,7 +41,7 @@
 @define-color base_color #{"" + bg_color(1)};
 @define-color theme_base_color #{"" + bg_color(1)};
 @define-color theme_unfocused_base_color #{"" + bg_color(1)};
-@define-color insensitive_base_color #{"" + bg_color(2)};
+@define-color insensitive_base_color #{"" + $insensitive-base-color};
 
 // Outset box shadow or border color on toplevel elements like windows, menus, popovers
 @define-color borders #{"" + $toplevel-border-color};

--- a/src/_index.scss
+++ b/src/_index.scss
@@ -62,7 +62,7 @@ $warning-icon-color: mix($BANANA_500, $BANANA_700, $weight: 50%);
 }
 
 // Disabled entries, views, checkbuttons, spinbuttons
-$insensitive-base-color: mix(bg_color(2), bg_color(3), $weight: 25%);
+$insensitive-base-color: mix(bg_color(2), bg_color(3), $weight: 10%);
 
 // Disabled text, images, other foreground elements
 $insensitive-fg-color: mix($fg-color, bg_color(2), $weight: 50%);

--- a/src/_index.scss
+++ b/src/_index.scss
@@ -61,6 +61,9 @@ $warning-icon-color: mix($BANANA_500, $BANANA_700, $weight: 50%);
     }
 }
 
+// Disabled entries, views, checkbuttons, spinbuttons
+$insensitive-base-color: mix(bg_color(2), bg_color(3), $weight: 25%);
+
 // Disabled text, images, other foreground elements
 $insensitive-fg-color: mix($fg-color, bg_color(2), $weight: 50%);
 

--- a/src/widgets/_checkbuttons.scss
+++ b/src/widgets/_checkbuttons.scss
@@ -29,7 +29,7 @@ radio {
     }
 
     &:disabled {
-        background: rgba(black, 0.03);
+        background: $insensitive-base-color;
         box-shadow: 0 1px 0 0 #{'alpha (@bg_highlight_color, 0.3)'};
         color: $insensitive-fg-color;
         -gtk-icon-shadow: 0 1px 1px #{'alpha (@bg_highlight_color, 0.3)'};

--- a/src/widgets/_entries.scss
+++ b/src/widgets/_entries.scss
@@ -7,7 +7,7 @@
     color: #{'@fg_color'};
 
     &:disabled {
-        background: rgba(black, 0.03);
+        background: $insensitive-base-color;
         box-shadow: inset-shadow("disabled");
         color: $insensitive-fg-color;
     }

--- a/src/widgets/_views.scss
+++ b/src/widgets/_views.scss
@@ -44,7 +44,7 @@ scrolledwindow {
     color: $fg-color;
 
     &:disabled {
-        background-color: #{'@insensitive_base_color'};
+        background-color: $insensitive-base-color;
         color: $insensitive-fg-color;
     }
 }


### PR DESCRIPTION
Fixes #803

Make insensitive base color relative to background levels and use it in entries (and thus spinbuttons), checkbuttons, and views. 