### PR TITLE
Buttons: suggested-action extends selection

### DIFF
--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -57,36 +57,28 @@ button {
         }
 
         &.suggested-action:not(:disabled) {
-            $accent-fg-color: #{'mix (black, @accent_color_900, 0.8)'};
-            $bg-color: #{'@accent_color_100'};
-            $border-color: #{'alpha (mix (black, @accent_color_300, 0.8), 0.4)'};
-            $checked-border-color: alpha #{'(@accent_color_500, 0.45)'};
+            @extend selection;
 
             @if $color-scheme == "light" {
-                background-clip: border-box;
-                box-shadow:
-                    outset-highlight("full"),
-                    0 1px 1px rgba(black, 0.07),
-                    0 1px 2px rgba(black, 0.2);
-            } @else if $color-scheme == "dark" {
-                $accent-fg-color: white;
-                $bg-color: #{'mix (black, @accent_color_300, 0.5)'};
-                $border-color: #{'alpha (@accent_color_900, 0.5)'};
-                $checked-border-color: rgba(black, 0.5);
-            }
+                border-color: #{'alpha (mix (black, @accent_color, 0.9), 0.5)'};
 
-            background-color: $bg-color;
-            border-color: $border-color;
+                &:backdrop {
+                    border-color: $border-color;
+                }
+            }
 
             image,
             label {
-                color: $accent-fg-color;
+                color: inherit;
             }
 
             &:active,
             &:checked {
-                background-color: $bg-color;
-                border-color: $checked-border-color;
+                @if $color-scheme == "light" {
+                    border-color: #{'alpha (mix (black, @accent_color, 0.7), 0.4)'};
+                } @else if $color-scheme == "dark" {
+                    border-color: rgba(black, 0.5);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #866 

Added benefit of less code and matching selection styles. Even if its too pastel in the light style or we like the brighter text in the dark style, I think this is the right direction to go in code and we can adjust the selection style to be more saturated if that's what we want

## BEFORE
![Screenshot from 2021-03-11 17 04 59@2x](https://user-images.githubusercontent.com/7277719/110876290-0d978c00-828c-11eb-9eb3-6246535ad70f.png)
![Screenshot from 2021-03-11 17 05 05@2x](https://user-images.githubusercontent.com/7277719/110876292-0e302280-828c-11eb-9770-138eb51fad68.png)

## AFTER
![Screenshot from 2021-03-11 17 04 11@2x](https://user-images.githubusercontent.com/7277719/110876287-0bcdc880-828c-11eb-865e-39465e30e6eb.png)
![Screenshot from 2021-03-11 17 04 25@2x](https://user-images.githubusercontent.com/7277719/110876288-0cfef580-828c-11eb-8564-6b2945287f5b.png)