### PR TITLE
Popovers: set correct margin and padding on h4

### DIFF
--- a/src/widgets/_popovers.scss
+++ b/src/widgets/_popovers.scss
@@ -5,6 +5,15 @@ popover {
     box-shadow: shadow(2);
     margin: 6px;
 
+    label.h4 {
+        margin: 0 rem(12px);
+    }
+
+    // Fixes extra padding in switch modelbuttons
+    menuitem.h4 label {
+        padding: 0;
+    }
+
     menuitem,
     modelbutton,
     .menuitem {


### PR DESCRIPTION
Fixes #981 

Also make sure we set the correct horizontal margin on h4 labels in popovers such as in the keyboard indicator when you configure multiple layouts and input methods