### PR TITLE
Improve Notebook styling

### DIFF
--- a/src/widgets/_notebooks.scss
+++ b/src/widgets/_notebooks.scss
@@ -3,25 +3,30 @@ notebook {
         background-color: bg-color(3);
 
         $gradient: 
-            rgba(black, 0),
-            rgba(black, 0) calc(100% - #{rem(2px)}),
-            rgba(black, 0.05) calc(100% - #{rem(1px)}),
-            rgba(black, 0.15);
+            rgba(black, 0.07) 0%,
+            rgba(black, 0.03) 20%,
+            rgba(black, 0.03) 80%,
+            rgba(black, 0.07) 100%;
+        $border: 1px solid rgba(black, 0.3);
 
         &.top {
             background-image: linear-gradient(to bottom, $gradient);
+            border-bottom: $border;
         }
 
         &.bottom {
             background-image: linear-gradient(to top, $gradient);
+            border-top: $border;
         }
 
         &.right {
             background-image: linear-gradient(to left, $gradient);
+            border-left: $border;
         }
 
         &.left {
             background-image: linear-gradient(to right, $gradient);
+            border-right: $border;
         }
 
         &:backdrop {
@@ -41,52 +46,78 @@ notebook {
 }
 
 tab {
-    $border-radius: rem(3px);
-    $margin: rem(6px);
+    // Not scaled because it's based on icon size
+    min-width: 24px;
+    padding: rem(4px);
 
+    // Set transparent borders for all tabs, since
+    // active tabs have borders and we don't want
+    // any shifts as a result of changing the border.
+    $border-radius: rem(4px);
+    $margin: rem(4px);
+    $border: 1px solid transparent;
     .top & {
         border-radius: $border-radius $border-radius 0 0;
         margin-top: $margin;
-        margin-bottom: 1px;
+        border-top: $border;
+        border-left: $border;
+        border-right: $border;
     }
 
     .bottom & {
         border-radius: 0 0 $border-radius $border-radius;
         margin-bottom: $margin;
+        border-bottom: $border;
+        border-left: $border;
+        border-right: $border;
     }
 
     .left & {
         border-radius: $border-radius 0 0 $border-radius;
         margin-left: $margin;
+        border-left: $border;
+        border-top: $border;
+        border-bottom: $border;
     }
 
     .right & {
         border-radius: 0 $border-radius $border-radius 0;
         margin-right: $margin;
+        border-right: $border;
+        border-top: $border;
+        border-bottom: $border;
     }
 
-    // Not scaled because it's based on icon size
-    min-width: 24px;
-    padding: rem(4px);
-
-    &:hover:not(:checked) {
-        background-color: bg-color(4);
-    }
-
+    // The box-shadow masks the bottom border of
+    // the notebook so the active tab doesn't have
+    // a border underneath it.
     &:checked {
         background-color: bg-color(1);
 
+        $border-color: rgba(black, 0.3);
         .top & {
-            box-shadow: 0 rem(-1px) 0 0 #{"@accent_color"};
+            border-top-color: $border-color;
+            border-left-color: $border-color;
+            border-right-color: $border-color;
+            box-shadow: 0 rem(1px) 0 0 bg-color(1);
         }
         .bottom & {
-            border-bottom: rem(2px) solid #{"@accent_color"};
+            border-bottom-color: $border-color;
+            border-left-color: $border-color;
+            border-right-color: $border-color;
+            box-shadow: 0 rem(-1px) 0 0 bg-color(1);
         }
         .left & {
-            border-left: rem(2px) solid #{"@accent_color"};
+            border-left-color: $border-color;
+            border-top-color: $border-color;
+            border-bottom-color: $border-color;
+            box-shadow: rem(1px) 0 0 0 bg-color(1);
         }
         .right & {
-            border-right: rem(2px) solid #{"@accent_color"};
+            border-right-color: $border-color;
+            border-top-color: $border-color;
+            border-bottom-color: $border-color;
+            box-shadow: rem(-1px) 0 0 0 bg-color(1);
         }
 
         &:backdrop {

--- a/src/widgets/_notebooks.scss
+++ b/src/widgets/_notebooks.scss
@@ -1,5 +1,3 @@
-
-
 notebook {
     header {
         background-color: bg-color(3);

--- a/src/widgets/_notebooks.scss
+++ b/src/widgets/_notebooks.scss
@@ -1,3 +1,5 @@
+
+
 notebook {
     header {
         background-color: bg-color(3);
@@ -41,23 +43,33 @@ notebook {
 }
 
 tab {
-    border-radius: rem(3px);
-    // Slow to match the close button revealer transition
-    transition: all 300ms ease-in;
+    $border-radius: rem(3px);
+    $margin: rem(6px);
 
-    .bottom &,
     .top & {
-        margin: rem(3px) 0;
+        border-radius: $border-radius $border-radius 0 0;
+        margin-top: $margin;
+        margin-bottom: 1px;
     }
 
-    .left &,
+    .bottom & {
+        border-radius: 0 0 $border-radius $border-radius;
+        margin-bottom: $margin;
+    }
+
+    .left & {
+        border-radius: $border-radius 0 0 $border-radius;
+        margin-left: $margin;
+    }
+
     .right & {
-        margin: 0 rem(3px);
+        border-radius: 0 $border-radius $border-radius 0;
+        margin-right: $margin;
     }
 
     // Not scaled because it's based on icon size
     min-width: 24px;
-    padding: rem(3px);
+    padding: rem(4px);
 
     &:hover:not(:checked) {
         background-color: bg-color(4);
@@ -65,10 +77,19 @@ tab {
 
     &:checked {
         background-color: bg-color(1);
-        box-shadow:
-            outset-highlight(),
-            0 0 0 1px rgba(black, 0.1),
-            outset-shadow(2);
+
+        .top & {
+            box-shadow: 0 rem(-1px) 0 0 #{"@accent_color"};
+        }
+        .bottom & {
+            border-bottom: rem(2px) solid #{"@accent_color"};
+        }
+        .left & {
+            border-left: rem(2px) solid #{"@accent_color"};
+        }
+        .right & {
+            border-right: rem(2px) solid #{"@accent_color"};
+        }
 
         &:backdrop {
             background-color: bg-color(2);

--- a/src/widgets/_popovers.scss
+++ b/src/widgets/_popovers.scss
@@ -5,6 +5,15 @@ popover {
     box-shadow: shadow(2);
     margin: 6px;
 
+    label.h4 {
+        margin: 0 rem(12px);
+    }
+
+    // Fixes extra padding in switch modelbuttons
+    menuitem.h4 label {
+        padding: 0;
+    }
+
     menuitem,
     modelbutton,
     .menuitem {


### PR DESCRIPTION
With light theme:

![notebook-files](https://user-images.githubusercontent.com/20506149/113544562-5f86b580-959d-11eb-8fec-d0f08ef3dbf8.png)

With dark theme:

![notebook-code](https://user-images.githubusercontent.com/20506149/113544571-63b2d300-959d-11eb-87e5-04d24aef880a.png)

Works with notebooks of all orientations (top, bottom, left & right):

![gtk-widget-factory-notebook](https://user-images.githubusercontent.com/20506149/113544576-68778700-959d-11eb-97a5-6f0269799111.png)


