### PR TITLE
Popovers: Remove modelmenu hack

### DIFF
--- a/src/widgets/_popovers.scss
+++ b/src/widgets/_popovers.scss
@@ -20,12 +20,6 @@ popover {
         @extend %menuitem;
     }
 
-    // Almost certainly means you are using ModelMenu
-    &.menu > stack {
-        // These are hardcoded values in Gtk, we don't want rems here
-        margin: -4px -10px;
-    }
-
     separator {
         &.horizontal {
             border-top: 1px solid #{'@menu_separator'};


### PR DESCRIPTION
Fixes #955 
This kind of made some modelmenus look better, but it really breaks some menus like in Akira and some other apps