### PR TITLE
Buttons: Add a background to checked flat buttons

### DIFF
--- a/src/widgets/_buttons.scss
+++ b/src/widgets/_buttons.scss
@@ -14,6 +14,10 @@ button {
         border: none;
         box-shadow: none;
 
+        &:checked {
+            background: rgba($fg-color, 0.15);
+        }
+
         &:focus {
             @extend selection;
             outline-style: none;
@@ -118,6 +122,7 @@ button {
             @if $color-scheme == "light" {
                 border-color: #{'@accent_color'};
             }
+            color: #{'@selected_fg_color'};
             outline-color: #{'alpha(@accent_color, 0.3)'};
             outline-width: rem(2px);
             outline-style: solid;


### PR DESCRIPTION
Fixes #1006

This follows the un-focused selection color as in list views. Focused items have accent color