### PR TITLE
Progressbars: Remove pulse image from backdrop

### DIFF
--- a/src/widgets/_progressbars.scss
+++ b/src/widgets/_progressbars.scss
@@ -64,6 +64,7 @@ progressbar {
 
             &:backdrop {
                 animation: none;
+                background-image: none;
                 @extend %outset-background;
             }
         }


### PR DESCRIPTION
Fixes #941 