### PR TITLE
Notebooks: use tab_base_color

### DIFF
--- a/src/_exported.scss
+++ b/src/_exported.scss
@@ -42,6 +42,7 @@
 @define-color theme_base_color #{"" + bg_color(1)};
 @define-color theme_unfocused_base_color #{"" + bg_color(1)};
 @define-color insensitive_base_color #{"" + $insensitive-base-color};
+@define-color tab_base_color #{'@base_color'};
 
 // Outset box shadow or border color on toplevel elements like windows, menus, popovers
 @define-color borders #{"" + $toplevel-border-color};

--- a/src/_exported.scss
+++ b/src/_exported.scss
@@ -29,12 +29,16 @@
 @define-color theme_unfocused_selected_bg_color #{'alpha(@text_color, 0.10)'};
 @define-color theme_unfocused_selected_fg_color #{"" + $fg-color};
 
+@define-color tab_base_color #{"" + bg_color(1)};
+
 @if $color-scheme == "dark" {
     @define-color menu_separator #{rgba(black, 0.25)};
     @define-color menu_separator_shadow #{rgba(white, 0.05)};
 
     @define-color selected_bg_color #{'alpha(shade(@accent_color, 0.85), 0.5)'};
     @define-color selected_fg_color #{'mix(shade(@accent_color, 1.1), white, 0.75)'};
+
+    @define-color tab_base_color #{"" + bg_color(2)};
 }
 
 // Used primarily for views and entries
@@ -42,7 +46,6 @@
 @define-color theme_base_color #{"" + bg_color(1)};
 @define-color theme_unfocused_base_color #{"" + bg_color(1)};
 @define-color insensitive_base_color #{"" + $insensitive-base-color};
-@define-color tab_base_color #{'@base_color'};
 
 // Outset box shadow or border color on toplevel elements like windows, menus, popovers
 @define-color borders #{"" + $toplevel-border-color};

--- a/src/widgets/_notebooks.scss
+++ b/src/widgets/_notebooks.scss
@@ -1,5 +1,5 @@
-tabbox {
-    background-color: bg-color(3);
+%tabheader {
+    background-color: #{'shade (@tab_base_color, 0.95)'};
 
     $gradient: 
         rgba(black, 0),
@@ -22,13 +22,13 @@ tabbox {
     }
 
     &:backdrop {
-        background-color: bg-color(2);
+        background-color: #{'shade (@tab_base_color, 0.98)'};
     }
 }
 
 notebook {
     header {
-        @extend tabbox;
+        @extend %tabheader;
 
         // Matches the new tab and history buttons
         > box > button.image-button,
@@ -61,13 +61,6 @@ tab {
     // Slow to match the close button revealer transition
     transition: all 300ms ease-in;
 
-    tabbox & {
-        background-clip: padding-box;
-        border: 1px solid transparent;
-        transition: all 150ms ease-in;
-    }
-
-    tabbox &,
     .bottom &,
     .top & {
         margin: rem(3px) 0;
@@ -88,23 +81,34 @@ tab {
     }
 
     &:hover:not(:checked) {
-        background-color: bg-color(4);
+        background-color: #{'shade (@tab_base_color, 0.9)'};
     }
 
     &:checked {
-        background-color: bg-color(1);
+        background-color: #{'@tab_base_color'};
         box-shadow:
             outset-highlight(),
             0 0 0 1px rgba(black, 0.1),
             outset-shadow(2);
 
-        tabbox & {
+        &:backdrop {
+            background-color: #{'shade (@tab_base_color, 0.97)'};
+        }
+    }
+}
+
+tabbox {
+    @extend %tabheader;
+
+    tab {
+        background-clip: padding-box;
+        border: 1px solid transparent;
+        margin: rem(3px) 0;
+        transition: all 150ms ease-in;
+
+        &:checked {
             border-color: rgba(black, 0.1);
             box-shadow: outset-highlight();
-        }
-
-        &:backdrop {
-            background-color: bg-color(2);
         }
     }
 }

--- a/src/widgets/_notebooks.scss
+++ b/src/widgets/_notebooks.scss
@@ -1,6 +1,11 @@
 %tabheader {
     background-color: #{'shade (@tab_base_color, 0.95)'};
 
+    @if $color-scheme == "dark" {
+        background-color: #{'shade (@tab_base_color, 0.87)'};
+    }
+
+
     $gradient: 
         rgba(black, 0),
         rgba(black, 0) calc(100% - #{rem(2px)}),


### PR DESCRIPTION
Fixes #1024 

No need for another style class anymore. Also self-contain hdy.tabbox a bit here to fix issues with box shadow