### PR TITLE
Scales: Add focus styles

### DIFF
--- a/src/widgets/_scales.scss
+++ b/src/widgets/_scales.scss
@@ -50,6 +50,21 @@ scale {
             border: none;
             box-shadow: none;
         }
+
+        &:focus {
+            @if $color-scheme == "light" {
+                box-shadow:
+                    outset-highlight("full"),
+                    0 0 0 rem(3px) #{'alpha(@accent_color, 0.3)'},
+                    0 0 0 1px $border-color,
+                    0 0 0 1px #{'@accent_color'};
+            } @else {
+                box-shadow:
+                    outset-highlight("full"),
+                    0 0 0 rem(3px) #{'alpha(@accent_color, 0.3)'},
+                    0 0 0 1px $border-color;
+            }
+        }
     }
 
     trough {


### PR DESCRIPTION
Fixes #1051 

It looks like outline doesn't affect switch sliders, so we have to use box-shadow here and do some funky layering to emulate it