### PR TITLE
Linked:specify image-button to override border-radius

### DIFF
--- a/src/widgets/_linked.scss
+++ b/src/widgets/_linked.scss
@@ -32,6 +32,7 @@
 
 viewswitcher > box > button.horizontal.radio,
 .linked:not(.vertical) > button,
+.linked:not(.vertical) > button.image-button,
 .linked:not(.vertical) > entry,
 .linked:not(.vertical) > spinbutton {
     &:not(:first-child) {
@@ -44,6 +45,7 @@ viewswitcher > box > button.horizontal.radio,
 }
 
 .linked.vertical > button,
+.linked.vertical > button.image-button,
 .linked.vertical > entry,
 .linked.vertical > spinbutton {
     &:not(:first-child) {


### PR DESCRIPTION
Fixes an issue with the linked selectors in Calendar (and probably other places). Linked image buttons are still linked, so make sure we're specific to give them the correct border radius