### PR TITLE
Headerbars: titlebar.flat inherits colors

### DIFF
--- a/src/widgets/_headerbars.scss
+++ b/src/widgets/_headerbars.scss
@@ -77,7 +77,8 @@ window {
             }
 
             &.flat {
-                background: bg_color(2);
+                background: inherit;
+                color: inherit;
                 box-shadow: outset-highlight("top");
             }
         }

--- a/src/widgets/_sidebars.scss
+++ b/src/widgets/_sidebars.scss
@@ -24,7 +24,6 @@
 
     &,
     list,
-    window.unified.csd & headerbar.titlebar.flat,
     .view {
         background-color: bg_color(3);
     }

--- a/src/widgets/_views.scss
+++ b/src/widgets/_views.scss
@@ -40,11 +40,11 @@ scrolledwindow {
 }
 
 .view {
-    background-color: #{'@base_color'};
+    background: #{'@base_color'};
     color: $fg-color;
 
     &:disabled {
-        background-color: $insensitive-base-color;
+        background: $insensitive-base-color;
         color: $insensitive-fg-color;
     }
 }


### PR DESCRIPTION
Fixes mismatched titlebar colors in flat titlebars by inheriting

## BEFORE
![Screenshot from 2021-08-18 12 34 26](https://user-images.githubusercontent.com/7277719/129964310-e766209a-3e7f-49d7-a97b-87e34e27c62e.png)

## AFTER
![Screenshot from 2021-08-18 13 00 52](https://user-images.githubusercontent.com/7277719/129964308-122557ec-20b0-4d14-86b2-142eee33ee49.png)
