### PR TITLE
Scales: don't require setting accent_500 for accent

### DIFF
--- a/src/widgets/_scales.scss
+++ b/src/widgets/_scales.scss
@@ -89,11 +89,11 @@ scale {
 
     &.accent {
         fill {
-            background-color: #{'alpha(@accent_color_500, 0.33)'};
+            background-color: #{'alpha(@accent_color, 0.33)'};
         }
 
         highlight {
-            background-color: #{'alpha (@accent_color_500, 0.67)'};
+            background-color: #{'@accent_color'};
         }
     }
 


### PR DESCRIPTION
Makes it so you can add `accent` class and only define `accent_color` to set accents for scales