### PR TITLE
Hdy.TabBar styling fixes

### DIFF
--- a/src/widgets/_notebooks.scss
+++ b/src/widgets/_notebooks.scss
@@ -6,7 +6,7 @@
     }
 
 
-    $gradient: 
+    $gradient:
         rgba(black, 0),
         rgba(black, 0) calc(100% - #{rem(2px)}),
         rgba(black, 0.05) calc(100% - #{rem(1px)}),
@@ -101,10 +101,12 @@ tab {
     }
 }
 
-tabbox {
-    @extend %tabheader;
+tabbar {
+    .box, .start-action, .end-action {
+        @extend %tabheader;
+    }
 
-    tab {
+    .box tab {
         background-clip: padding-box;
         border: 1px solid transparent;
         margin: rem(3px) 0;


### PR DESCRIPTION
This picks up the `.start-action` and `.end-action` classes and also ensures they have a correctly styled background. These are the containers on either end of the TabBar that optionally exist to hold static widgets (e.g. the new tab button and tab overflow dropdown in Ephy).

There's still an issue where the left/right borders of the first/last tabs aren't drawn. This can be fixed by adding a 1px left/right margin to all tabs, but I presume we don't want this for stylistic reasons. Not savvy enough with CSS to figure out a different fix.

The `.start-action` and `.end-action` stuff can be tested with https://github.com/elementary/browser/pull/41 , the tab border stuff is visible in the Handy example app.