### PR TITLE
Use the accent color for highlighting in IBus candidate window

### DIFF
--- a/data/stylesheet.appdata.xml.in
+++ b/data/stylesheet.appdata.xml.in
@@ -14,6 +14,11 @@
     <id>io.elementary.stylesheet</id>
   </provides>
   <releases>
+    <release version="6.2.0" date="2021-11-16" urgency="medium">
+      <ul>
+        <li>Use the accent color for highlighting in IBus candidate window</li>
+      </ul>
+    </release>
     <release version="6.1.0" date="2021-10-22" urgency="medium">
       <ul>
         <li>Support for Hdy.Tabbar</li>

--- a/src/widgets/_views.scss
+++ b/src/widgets/_views.scss
@@ -42,6 +42,7 @@ scrolledwindow {
 .view {
     background: #{'@base_color'};
     color: $fg-color;
+    -gtk-secondary-caret-color: #{'@accent_color_100'};
 
     &:disabled {
         background: $insensitive-base-color;

--- a/src/widgets/_views.scss
+++ b/src/widgets/_views.scss
@@ -42,7 +42,7 @@ scrolledwindow {
 .view {
     background: #{'@base_color'};
     color: $fg-color;
-    -gtk-secondary-caret-color: #{'@accent_color_100'};
+    -gtk-secondary-caret-color: #{'@selected_bg_color'};
 
     &:disabled {
         background: $insensitive-base-color;


### PR DESCRIPTION
Fixes #1067

## Before
![2021-11-16 12 07 05 のスクリーンショット](https://user-images.githubusercontent.com/26003928/141889315-5fa821e5-5667-47ea-a44c-746d38b0e8d5.png)

The highlight word in IBus candidate window is redacted and unreadable.

## After
![2021-11-16 12 05 34 のスクリーンショット](https://user-images.githubusercontent.com/26003928/141889308-e996aac4-2c41-44d4-b517-9f8c4f10fc43.png)

Now the highlight word uses the accent color preferred in System Settings, so it's visible and plus provides design consistency.

I'm not familiar with the structure of this repository, so feel free to move the changes to the appropriate place.
