### PR TITLE
GTK4/Headerbars: .titlebutton → windowcontrols

### DIFF
--- a/src/gtk-4.0/widgets/_buttons.scss
+++ b/src/gtk-4.0/widgets/_buttons.scss
@@ -99,12 +99,6 @@ button {
             }
         }
 
-        &.titlebutton:not(:active) {
-            background: none;
-            border-color: transparent;
-            box-shadow: none;
-        }
-
         &:active,
         &:checked {
             background: rgba(black, 0.05);
@@ -180,8 +174,7 @@ button {
 
     &.color,
     &.combo,
-    &.image-button,
-    &.titlebutton {
+    &.image-button {
         padding: rem(4px);
     }
 

--- a/src/gtk-4.0/widgets/_headerbars.scss
+++ b/src/gtk-4.0/widgets/_headerbars.scss
@@ -40,25 +40,8 @@ window {
             -gtk-icon-shadow: $shadow;
         }
 
-        windowcontrols {
-            &.end {
-                margin-left: rem(12px);
-            }
-
-            &.start {
-                margin-right: rem(12px);
-            }
-
-            button {
-                padding: rem(4px);
-                -gtk-icon-shadow: $shadow;
-
-                &:not(:active) {
-                    background: none;
-                    border-color: transparent;
-                    box-shadow: none;
-                }
-            }
+        windowcontrols button {
+            -gtk-icon-shadow: $shadow;
         }
 
         // Reset so we don't affect things inside of child popovers/menus

--- a/src/gtk-4.0/widgets/_headerbars.scss
+++ b/src/gtk-4.0/widgets/_headerbars.scss
@@ -35,12 +35,9 @@ window {
             font-size: 80%;
         }
 
+        windowcontrols button,
         .image-button,
         .mode-switch {
-            -gtk-icon-shadow: $shadow;
-        }
-
-        windowcontrols button {
             -gtk-icon-shadow: $shadow;
         }
 

--- a/src/gtk-4.0/widgets/_headerbars.scss
+++ b/src/gtk-4.0/widgets/_headerbars.scss
@@ -35,10 +35,30 @@ window {
             font-size: 80%;
         }
 
-        .titlebutton,
         .image-button,
         .mode-switch {
             -gtk-icon-shadow: $shadow;
+        }
+
+        windowcontrols {
+            &.end {
+                margin-left: rem(12px);
+            }
+
+            &.start {
+                margin-right: rem(12px);
+            }
+
+            button {
+                padding: rem(4px);
+                -gtk-icon-shadow: $shadow;
+
+                &:not(:active) {
+                    background: none;
+                    border-color: transparent;
+                    box-shadow: none;
+                }
+            }
         }
 
         // Reset so we don't affect things inside of child popovers/menus

--- a/src/gtk-4.0/widgets/_index.scss
+++ b/src/gtk-4.0/widgets/_index.scss
@@ -91,4 +91,5 @@ selection {
 @import '_treeviews.scss';
 @import '_views.scss';
 @import '_viewswitcher.scss';
+@import '_windowcontrols.scss';
 @import '_windows.scss';

--- a/src/gtk-4.0/widgets/_separators.scss
+++ b/src/gtk-4.0/widgets/_separators.scss
@@ -21,9 +21,4 @@ separator {
     stacksidebar &.horizontal {
         border: none;
     }
-
-    &.titlebutton {
-        border: none;
-        margin: 0 rem(3px);
-    }
 }

--- a/src/gtk-4.0/widgets/_windowcontrols.scss
+++ b/src/gtk-4.0/widgets/_windowcontrols.scss
@@ -1,0 +1,19 @@
+windowcontrols {
+    &.end {
+        margin-left: rem(12px);
+    }
+
+    &.start {
+        margin-right: rem(12px);
+    }
+
+    button {
+        padding: rem(4px);
+
+        &:not(:active) {
+            background: none;
+            border-color: transparent;
+            box-shadow: none;
+        }
+    }
+}


### PR DESCRIPTION
.titlebutton isn't a thing anymore. Instead there's an element `windowcontrols` which contains all the title buttons

There's also no longer a separator in headerbar, so to maintain margins here we can add margin to the `windowcontrols` widget

## BEFORE
![Screenshot from 2021-11-26 18 06 33@2x](https://user-images.githubusercontent.com/7277719/143664792-eeff1804-1520-418d-97ae-6f9fbf4f896e.png)

## AFTER
![Screenshot from 2021-11-26 18 06 11@2x](https://user-images.githubusercontent.com/7277719/143664794-40133445-7c0a-4f26-b17c-8acf602565ee.png)