### PR TITLE
GTK4/Windows,Headerbars: fix decorations for dialogs

### DIFF
--- a/src/gtk-4.0/widgets/_headerbars.scss
+++ b/src/gtk-4.0/widgets/_headerbars.scss
@@ -139,18 +139,5 @@ window {
 }
 
 window.dialog.csd > .titlebar {
-   background: inherit;
-   box-shadow: outset-highlight("top");
-   padding: rem(6px);
-
-   &.default-decoration {
-       padding: 0;
-   }
-
-   label.title {
-       text-shadow: none;
-       -gtk-icon-shadow: none;
-       font-size: 0.1px; // Workaround for an issue in Gtk when setting 0px
-       color: transparent;
-   }
+    @extend .flat;
 }

--- a/src/gtk-4.0/widgets/_headerbars.scss
+++ b/src/gtk-4.0/widgets/_headerbars.scss
@@ -1,7 +1,4 @@
 assistant,
-dialog,
-messagedialog,
-message-dialog,
 printdialog,
 window.csd {
     > .titlebar {
@@ -141,23 +138,19 @@ window {
     }
 }
 
-dialog.csd,
-messagedialog.csd,
-message-dialog.csd {
-    > .titlebar {
-       background-color: bg_color(2);
-       box-shadow: outset-highlight("top");
-       padding: rem(6px);
+window.dialog.csd > .titlebar {
+   background: inherit;
+   box-shadow: outset-highlight("top");
+   padding: rem(6px);
 
-       &.default-decoration {
-           padding: 0;
-       }
+   &.default-decoration {
+       padding: 0;
+   }
 
-       label.title {
-           text-shadow: none;
-           -gtk-icon-shadow: none;
-           font-size: 0.1px; // Workaround for an issue in Gtk when setting 0px
-           color: transparent;
-       }
+   label.title {
+       text-shadow: none;
+       -gtk-icon-shadow: none;
+       font-size: 0.1px; // Workaround for an issue in Gtk when setting 0px
+       color: transparent;
    }
 }

--- a/src/gtk-4.0/widgets/_windows.scss
+++ b/src/gtk-4.0/widgets/_windows.scss
@@ -5,9 +5,6 @@
 }
 
 assistant,
-dialog,
-messagedialog,
-message-dialog,
 printdialog,
 window.csd:not(.popup):not(.menu) {
     margin: rem(12px);
@@ -15,7 +12,7 @@ window.csd:not(.popup):not(.menu) {
 
 assistant,
 printdialog,
-window:not(.popup):not(.menu) {
+window {
     border-radius: 6px 6px 0 0;
 
     // We only draw shadows for client-side decorations
@@ -78,42 +75,40 @@ window:not(.popup):not(.menu) {
     }
 }
 
-dialog,
-messagedialog,
-message-dialog {
+window.dialog {
+    border-radius: 0;
     box-shadow: outset-highlight("bottom");
 
-    border-radius: rem(6px);
-    box-shadow:
-        // Intentionally not in ems since it's used as a stroke
-        0 0 0 1px $toplevel-border-color,
-        // Force shadows to be the same size to prevent jumpy resize transition
-        0 13px 16px 4px transparent,
-        shadow(3);
-
-    &:backdrop {
+    &.csd {
+        border-radius: rem(6px);
         box-shadow:
+            outset-highlight(),
             // Intentionally not in ems since it's used as a stroke
             0 0 0 1px $toplevel-border-color,
             // Force shadows to be the same size to prevent jumpy resize transition
             0 13px 16px 4px transparent,
-            shadow(2);
+            shadow(3);
+
+        &:backdrop {
+            box-shadow:
+                outset-highlight(),
+                // Intentionally not in ems since it's used as a stroke
+                0 0 0 1px $toplevel-border-color,
+                // Force shadows to be the same size to prevent jumpy resize transition
+                0 13px 16px 4px transparent,
+                shadow(2);
+        }
     }
 
-    &.csd {
-        border-radius: 0 0 rem(6px) rem(6px);
-    }
-
-    // These should should in 12px borders around buttons
+    // These should be 12px borders around buttons
     .dialog-action-area {
         // Compensate for off-by-one
         margin: rem(7px);
         margin-bottom: rem(8px);
     }
-}
 
-messagedialog .dialog-action-area,
-message-dialog .dialog-action-area {
-    // Double space between content and actions
-    margin-top: rem(16px);
+    &.message .dialog-action-area {
+        // Double space between content and actions
+        margin-top: rem(16px);
+    }
 }


### PR DESCRIPTION
There's no longer separate element names for different types of windows. Instead, a window is a window and there are different classes (makes total sense!). This branch fixes decorations for SSD and CSD dialogs, and makes some progress (but not perfect) towards `window.dialog.message` support.

We intentionally hide titles in dialogs in the GTK3 version of our stylesheet already. Since we have a Granite.Dialog/Granite.MessageDialog I'm not sure if we want to stop doing that?

## BEFORE
![Screenshot from 2021-11-28 14 45 56@2x](https://user-images.githubusercontent.com/7277719/143789339-8badc26a-c0fa-48c4-9d27-b3a6d6bd5b2c.png)
![Screenshot from 2021-11-28 14 45 50@2x](https://user-images.githubusercontent.com/7277719/143789341-b05b600f-85cb-4b67-9de4-4e08a43706b1.png)
![Screenshot from 2021-11-28 14 45 45@2x](https://user-images.githubusercontent.com/7277719/143789342-210479c3-f062-4993-9cf2-d6515ecf7578.png)
![Screenshot from 2021-11-28 14 45 39@2x](https://user-images.githubusercontent.com/7277719/143789344-b12db2ba-149d-468f-8321-ebccf1bc827b.png)

## AFTER
![Screenshot from 2021-11-28 14 45 04@2x](https://user-images.githubusercontent.com/7277719/143789381-0c188cea-5460-4167-8d75-853dad629d45.png)
![Screenshot from 2021-11-28 14 44 57@2x](https://user-images.githubusercontent.com/7277719/143789382-50f3eb36-f3c3-4389-8c08-b2396a1a1658.png)
![Screenshot from 2021-11-28 14 44 52@2x](https://user-images.githubusercontent.com/7277719/143789384-5960afd8-8c4d-4556-99b8-22ba99da3bad.png)
![Screenshot from 2021-11-28 14 44 45@2x](https://user-images.githubusercontent.com/7277719/143789387-4b2edf72-ed5e-46b7-9410-f784cc63d338.png)
