### PR TITLE
GTK4/Expanders: remove arrow node

### DIFF
--- a/src/gtk-4.0/widgets/_expanders.scss
+++ b/src/gtk-4.0/widgets/_expanders.scss
@@ -1,4 +1,4 @@
-expander arrow,
+expander,
 .expander,
 .category-expander {
     min-height: 16px;


### PR DESCRIPTION
No more `arrow` element here, just `expander`