### PR TITLE
Treeview: set title font-weight as bold

### DIFF
--- a/src/gtk-3.0/widgets/_treeviews.scss
+++ b/src/gtk-3.0/widgets/_treeviews.scss
@@ -25,6 +25,7 @@ treeview {
         }
 
         label {
+            // Cannot be a number or fonts break in Flatpak
             font-weight: bold;
             opacity: 0.8;
         }

--- a/src/gtk-3.0/widgets/_treeviews.scss
+++ b/src/gtk-3.0/widgets/_treeviews.scss
@@ -25,7 +25,7 @@ treeview {
         }
 
         label {
-            font-weight: 600;
+            font-weight: bold;
             opacity: 0.8;
         }
 

--- a/src/gtk-4.0/widgets/_treeviews.scss
+++ b/src/gtk-4.0/widgets/_treeviews.scss
@@ -25,7 +25,8 @@ treeview {
         }
 
         label {
-            font-weight: 600;
+            // Cannot be a number or fonts break in Flatpak
+            font-weight: bold;
             opacity: 0.8;
         }
 


### PR DESCRIPTION
Fixes #1120
The same fix with #1102 by @danrabbit works! :tada:

You can test if this works by building https://github.com/ryonakano/junk/tree/file-chooser-test-css-test as Flatpak
