### PR TITLE
GTK4: Replace icon-effect with filter

### DIFF
--- a/src/gtk-4.0/_index.scss
+++ b/src/gtk-4.0/_index.scss
@@ -12,7 +12,7 @@ $border-color: rgba(black, 0.2);
 
 // Disabled entries, views, checkbuttons, spinbuttons
 $insensitive-base-color: rgba(0, 0, 0, 0.03);
-$disabled_opacity: 0.5;
+$disabled-opacity: 0.5;
 
 // Semantic colors
 $error_color: $STRAWBERRY_500;

--- a/src/gtk-4.0/_index.scss
+++ b/src/gtk-4.0/_index.scss
@@ -12,6 +12,7 @@ $border-color: rgba(black, 0.2);
 
 // Disabled entries, views, checkbuttons, spinbuttons
 $insensitive-base-color: rgba(0, 0, 0, 0.03);
+$disabled_opacity: 0.5;
 
 // Semantic colors
 $error_color: $STRAWBERRY_500;

--- a/src/gtk-4.0/widgets/_buttons.scss
+++ b/src/gtk-4.0/widgets/_buttons.scss
@@ -175,7 +175,7 @@ button {
     }
 
     &:backdrop {
-        -gtk-icon-effect: dim;
+        filter: opacity($disabled_opacity);
     }
 
     &.color,

--- a/src/gtk-4.0/widgets/_buttons.scss
+++ b/src/gtk-4.0/widgets/_buttons.scss
@@ -175,7 +175,7 @@ button {
     }
 
     &:backdrop {
-        filter: opacity($disabled_opacity);
+        filter: opacity($disabled-opacity);
     }
 
     &.color,

--- a/src/gtk-4.0/widgets/_images.scss
+++ b/src/gtk-4.0/widgets/_images.scss
@@ -5,6 +5,6 @@ image {
         warning $warning-icon-color;
 
     &:disabled {
-        -gtk-icon-effect: dim;
+        filter: opacity($disabled_opacity);
     }
 }

--- a/src/gtk-4.0/widgets/_images.scss
+++ b/src/gtk-4.0/widgets/_images.scss
@@ -5,6 +5,6 @@ image {
         warning $warning-icon-color;
 
     &:disabled {
-        filter: opacity($disabled_opacity);
+        filter: opacity($disabled-opacity);
     }
 }

--- a/src/gtk-4.0/widgets/_index.scss
+++ b/src/gtk-4.0/widgets/_index.scss
@@ -1,7 +1,3 @@
-image:disabled {
-    -gtk-icon-effect: dim;
-}
-
 selection {
     background-color: #{'@selected_bg_color'};
     color: #{'@selected_fg_color'};

--- a/src/gtk-4.0/widgets/_spinners.scss
+++ b/src/gtk-4.0/widgets/_spinners.scss
@@ -12,7 +12,7 @@ spinner {
         }
 
         &:disabled {
-            opacity: $disabled_opacity;
+            opacity: $disabled-opacity;
         }
     }
 }

--- a/src/gtk-4.0/widgets/_spinners.scss
+++ b/src/gtk-4.0/widgets/_spinners.scss
@@ -12,7 +12,7 @@ spinner {
         }
 
         &:disabled {
-            opacity: 0.4;
+            opacity: $disabled_opacity;
         }
     }
 }


### PR DESCRIPTION
This is based on how Adwaita replaced `-gtk-icon-effect` which no longer exists

See for example: https://github.com/GNOME/libadwaita/search?l=SCSS&q=icon+dim