### PR TITLE
GTK4/Icons: support IconSize

### DIFF
--- a/src/gtk-4.0/widgets/_images.scss
+++ b/src/gtk-4.0/widgets/_images.scss
@@ -7,4 +7,12 @@ image {
     &:disabled {
         -gtk-icon-effect: dim;
     }
+
+    &.normal-icons {
+        -gtk-icon-size: 16px;
+    }
+
+    &.large-icons {
+        -gtk-icon-size: 32px;
+    }
 }


### PR DESCRIPTION
Gtk4 drops the old prescriptive icon size and let's us define what icon size means in CSS with only two built-in options "Normal" and "Large". https://github.com/GNOME/gtk/blob/50e4ca8593d12b2de76e4d092d34ec7a1655ede8/gtk/gtkimage.c#L77

Adwaita's defaults are 16px and 32px, so that's what I've left here.

I imagine in future branches we might want to change this so that for example large images in buttons are 24px instead but large images in lists are 32px

Either way, `pixel_size` is still available, so this is just a convenience property and not super critical