### PR TITLE
GTK4/Scales: sliders to the end

### DIFF
--- a/src/gtk-4.0/widgets/_scales.scss
+++ b/src/gtk-4.0/widgets/_scales.scss
@@ -161,14 +161,14 @@ scale {
         fill.top {
             border-radius: rem(12px) 0 0 rem(12px);
             // Account for border width
-            margin: -1px 0 -1px calc(#{rem(-6px)} - 1px);
+            margin: -1px 0 -1px -1px;
         }
 
         highlight.bottom,
         fill.bottom {
             border-radius: 0 rem(12px) rem(12px) 0;
             // Account for border width
-            margin: -1px calc(#{rem(-6px)} - 1px) -1px 0;
+            margin: -1px -1px -1px 0;
         }
 
         mark indicator {
@@ -178,12 +178,11 @@ scale {
         }
 
         slider {
-            margin: rem(-6px) 0;
+            margin: rem(-6px) -1px;
         }
 
         trough {
             margin: rem(6px) 0;
-            padding: 0 rem(6px);
         }
     }
 
@@ -192,14 +191,14 @@ scale {
         fill.top {
             border-radius: rem(12px) rem(12px) 0 0;
             // Account for border width
-            margin: calc(#{rem(-6px)} - 1px) -1px 0 -1px;
+            margin: -1px -1px 0 -1px;
         }
 
         highlight.bottom,
         fill.bottom {
             border-radius: 0 0 rem(12px) rem(12px);
             // Account for border width
-            margin: 0 -1px calc(#{rem(-6px)} - 1px) -1px;
+            margin: 0 -1px -1px -1px;
         }
 
         mark indicator {
@@ -209,12 +208,11 @@ scale {
         }
 
         slider {
-            margin: 0 rem(-6px);
+            margin: -1px rem(-6px);
         }
 
         trough {
             margin: 0 rem(6px);
-            padding: rem(6px) 0;
         }
     }
 }


### PR DESCRIPTION
Fixes an issue where scale slides couldn't be dragged all the way to the ends:

## BEFORE
![Screenshot from 2022-01-03 15 36 55](https://user-images.githubusercontent.com/7277719/147991735-72741274-7292-4037-9d8d-cea6d27e00a7.png)

## AFTER
![Screenshot from 2022-01-03 15 36 28](https://user-images.githubusercontent.com/7277719/147991739-2b5e5f6e-a81b-4dac-81e3-3d26ed674939.png)
