### PR TITLE
GTK4/ColorChoosers: remove overlay margin

### DIFF
--- a/src/gtk-4.0/widgets/_colorchoosers.scss
+++ b/src/gtk-4.0/widgets/_colorchoosers.scss
@@ -49,7 +49,6 @@ colorchooser {
             border: 1px solid rgba(black, 0.2);
             border-bottom-width: 0;
             border-top-width: 0;
-            margin: -1px 3px;
 
             @if $color-scheme == "dark" {
                 box-shadow:


### PR DESCRIPTION
## BEFORE

![Screenshot from 2022-01-03 17 01 51](https://user-images.githubusercontent.com/7277719/147996254-dd85c83f-f6da-4847-b9d6-d8007a6090d5.png)

## AFTER

![Screenshot from 2022-01-03 17 01 46](https://user-images.githubusercontent.com/7277719/147996255-abe9de69-026c-4b9d-898c-a79c09a44748.png)
