### PR TITLE
GTK4/Calendars: fix and imitate date-time indicator

### DIFF
--- a/src/gtk-4.0/widgets/_calendars.scss
+++ b/src/gtk-4.0/widgets/_calendars.scss
@@ -1,25 +1,24 @@
-calendar {
-    // Days don't stay centered in the selection with larger padding
-    padding: rem(1px);
+calendar.view {
+    background: transparent;
 
-    .view {
-        background-color: transparent;
-        background-image: none;
+    .day-name {
+        @extend .h4;
     }
 
-    // Month headers
-    .highlight {
-        color: mix($fg-color, bg-color(1), $weight: 80%);
-    }
+    .day-number {
+        &.today {
+            @extend .accent;
+            font-weight: bold;
+        }
 
-    &:selected{
-        @extend selection;
-        border-radius: 99px;
-    }
+        &.other-month {
+            color: $insensitive-fg-color;
+        }
 
-    // Other month days
-    &:indeterminate {
-        color: mix($fg-color, bg-color(1), $weight: 50%);
+        &:selected{
+            @extend selection;
+            border-radius: 99px;
+        }
     }
 }
 


### PR DESCRIPTION
Imitates styles from Date & Time indicator:
* Today is bold and accent colored even when not selected
* h4 headers

### GTK3

![Screenshot from 2022-01-03 18 24 19](https://user-images.githubusercontent.com/7277719/148001308-883cecef-0685-4067-aafc-6ab2f4d3a75b.png)

### GTK4 Before
![Screenshot from 2022-01-03 18 24 03](https://user-images.githubusercontent.com/7277719/148001311-24109c9f-e95c-4e56-8087-746deb6033c0.png)

### GTK4 After
![Screenshot from 2022-01-03 18 22 50](https://user-images.githubusercontent.com/7277719/148001313-6f485be7-7bb1-4531-8f3d-1ce30319bb23.png)
