### PR TITLE
GTK4/Entries: progress size and style

### DIFF
--- a/src/gtk-4.0/widgets/_entries.scss
+++ b/src/gtk-4.0/widgets/_entries.scss
@@ -41,20 +41,18 @@ entry {
     @extend %entry;
     // Prevent size change when setting primary or secondary icons
     min-height: 16px;
-    // Off-by-one to account for padding-box clip
-    padding: rem(4px);
+
+    image,
+    text {
+        // Margin top and bottom for size, padding left and right for overflow
+        // Off-by-one to account for padding-box clip
+        margin: rem(4px) 0;
+        padding: 0 rem(4px);
+    }
 
     image {
         color: #{'@placeholder_text_color'};
         transition: all duration("in-place") $easing;
-    }
-
-    image.left {
-        margin-right: rem(6px);
-    }
-
-    image.right {
-        margin-left: rem(6px);
     }
 
     // We only want the action side icon to react on hover
@@ -66,5 +64,17 @@ entry {
     // Fixes an issue in Epiphany
     headerbar & {
         margin: 1px;
+    }
+
+    progress > trough {
+        // Off-by-one to account for padding-box clip
+        margin: rem(4px);
+
+        > progress {
+            background: #{'@accent_color'};
+            border-radius: rem(2px);
+            min-height: rem(2px);
+            min-width: rem(2px);
+        }
     }
 }


### PR DESCRIPTION
Fixes #1142 
Padding/Margin was moved to image and text inside entries instead of on the entry itself. This prevents the entry from growing to an unreasonable height with the progress element inside it.

## BEFORE
![Screenshot from 2022-01-04 11 22 30](https://user-images.githubusercontent.com/7277719/148112487-27c5dbc9-f252-4ddf-ba4c-a797d50c265f.png)

## AFTER
![Screenshot from 2022-01-04 11 22 00](https://user-images.githubusercontent.com/7277719/148112492-f587c321-4e11-4a78-a7ce-86e016473a17.png)
