### PR TITLE
GTK4: style accelerator node

### DIFF
--- a/src/gtk-4.0/_typography.scss
+++ b/src/gtk-4.0/_typography.scss
@@ -137,6 +137,7 @@ label:disabled {
     color: $insensitive-fg-color;
 }
 
+accelerator,
 .keycap {
     background-color: bg-color(2);
     background-image:

--- a/src/gtk-4.0/widgets/_popovers.scss
+++ b/src/gtk-4.0/widgets/_popovers.scss
@@ -9,6 +9,7 @@
     &:disabled {
         color: $insensitive-fg-color;
 
+        accelerator,
         .keycap {
             opacity: 0.7;
         }
@@ -27,6 +28,7 @@
         }
     }
 
+    accelerator,
     .keycap {
         background: rgba(black, 0.08);
         border: none;


### PR DESCRIPTION
Fixes ##1139

Styles them the same as Granite AccelLabel, with the exception that they use a single label so each key can't be its own thing for the stock GTK accels

![Screenshot from 2022-01-04 14 38 57](https://user-images.githubusercontent.com/7277719/148133768-df6164bd-2c16-4768-adb0-1ce1beedbb13.png)
