### PR TITLE
GTK4/Spinbuttons: fix padding and active style

### DIFF
--- a/src/gtk-4.0/widgets/_spinbuttons.scss
+++ b/src/gtk-4.0/widgets/_spinbuttons.scss
@@ -1,18 +1,13 @@
 spinbutton {
     @extend %entry;
 
-    button,
-    button:disabled,
-    entry,
-    entry:disabled,
-    entry:focus {
-        background: none;
-        border: none;
-        box-shadow: none;
-    }
+    button.image-button:active {
+        background: rgba(black, 0.05);
+        color: #{'@selected_fg_color'};
 
-    button:active {
-        box-shadow: none;
+        @if $color-scheme == "dark" {
+            background: rgba(black, 0.15);
+        }
     }
 
     &.horizontal {
@@ -37,22 +32,28 @@ spinbutton {
             }
         }
 
-        entry {
-            margin: 0 rem(3px);
+        text {
+            margin: 0 rem(6px);
         }
     }
 
-    &.vertical button {
-        &.down {
-            border-top: 1px solid rgba(black, 0.1);
-            border-top-left-radius: 0;
-            border-top-right-radius: 0;
+    &.vertical {
+        button {
+            &.down {
+                border-top: 1px solid rgba(black, 0.1);
+                border-top-left-radius: 0;
+                border-top-right-radius: 0;
+            }
+
+            &.up {
+                border-bottom: 1px solid rgba(black, 0.1);
+                border-bottom-left-radius: 0;
+                border-bottom-right-radius: 0;
+            }
         }
 
-        &.up {
-            border-bottom: 1px solid rgba(black, 0.1);
-            border-bottom-left-radius: 0;
-            border-bottom-right-radius: 0;
+        text {
+            margin: rem(6px) 0;
         }
     }
 }


### PR DESCRIPTION
Fixes #1132

* `entry` node no longer exists, style `text` instead
* `button`s are now `.image-button`, so less to override but needs active styles

## BEFORE
![Screenshot from 2022-01-04 15 06 43](https://user-images.githubusercontent.com/7277719/148136042-fd39be69-edbe-4885-9040-486e8fe283c6.png)
![Screenshot from 2022-01-04 15 06 36](https://user-images.githubusercontent.com/7277719/148136043-3fbda90a-87f6-41f9-809f-69ec8bb9ca6f.png)

## AFTER
![Screenshot from 2022-01-04 15 06 08](https://user-images.githubusercontent.com/7277719/148136116-4c1ef720-9897-4916-be84-f1f0e3986c20.png)
![Screenshot from 2022-01-04 15 06 00](https://user-images.githubusercontent.com/7277719/148136118-f0cb6db9-0962-4620-8928-2c140e9e1a79.png)
