### PR TITLE
GTK4: style ShortcutWindow

### DIFF
--- a/src/gtk-4.0/_typography.scss
+++ b/src/gtk-4.0/_typography.scss
@@ -137,36 +137,6 @@ label:disabled {
     color: $insensitive-fg-color;
 }
 
-accelerator,
-.keycap {
-    background-color: bg-color(2);
-    background-image:
-        linear-gradient(
-            to bottom,
-            rgba(white, 0),
-            #{'alpha(@highlight_color, 0.2)'}
-        );
-    border: 1px solid $toplevel-border-color;
-    border-radius: rem(3px);
-    box-shadow:
-        outset-highlight(),
-        inset 0 -1px 0 0 bg-color(4),
-        0 1px 2px rgba(black, 0.05);
-    font-size: 85%;
-    min-width: rem(12px);
-    // We add 1px on the bottom to account for box-shadow
-    padding: rem(3px) rem(6px) calc(#{rem(3px)} + 1px);
-
-    &:backdrop {
-        background-image:
-            linear-gradient(
-                to bottom,
-                #{'alpha(@highlight_color, 0.3)'},
-                #{'alpha(@highlight_color, 0.35)'}
-            );
-    }
-}
-
 :link:hover label {
   text-decoration: underline;
 }

--- a/src/gtk-4.0/widgets/_index.scss
+++ b/src/gtk-4.0/widgets/_index.scss
@@ -74,6 +74,7 @@ selection {
 @import '_scales.scss';
 @import '_scrollbars.scss';
 @import '_separators.scss';
+@import '_shortcuts.scss';
 @import '_sidebars.scss';
 @import '_spinbuttons.scss';
 @import '_spinners.scss';

--- a/src/gtk-4.0/widgets/_shortcuts.scss
+++ b/src/gtk-4.0/widgets/_shortcuts.scss
@@ -6,11 +6,6 @@ shortcuts-group > label {
     @extend .h4;
 }
 
-// Remove plus signs in Gtk.ShortcutLabel
-shortcut .dim-label {
-    color: transparent;
-}
-
 accelerator,
 .keycap {
     background-color: bg-color(2);

--- a/src/gtk-4.0/widgets/_shortcuts.scss
+++ b/src/gtk-4.0/widgets/_shortcuts.scss
@@ -6,6 +6,12 @@ shortcuts-group > label {
     @extend .h4;
 }
 
+// Characters between keys in Gtk.ShortcutLabel, like + or /
+ shortcut .dim-label {
+     margin-left: rem(3px);
+     margin-right: rem(3px);
+ }
+ 
 accelerator,
 .keycap {
     background-color: bg-color(2);

--- a/src/gtk-4.0/widgets/_shortcuts.scss
+++ b/src/gtk-4.0/widgets/_shortcuts.scss
@@ -1,0 +1,42 @@
+shortcuts-section {
+    margin: rem(12px);
+}
+
+shortcuts-group > label {
+    @extend .h4;
+}
+
+// Remove plus signs in Gtk.ShortcutLabel
+shortcut .dim-label {
+    color: transparent;
+}
+
+accelerator,
+.keycap {
+    background-color: bg-color(2);
+    background-image:
+        linear-gradient(
+            to bottom,
+            rgba(white, 0),
+            #{'alpha(@highlight_color, 0.2)'}
+        );
+    border: 1px solid $toplevel-border-color;
+    border-radius: rem(3px);
+    box-shadow:
+        outset-highlight(),
+        inset 0 -1px 0 0 bg-color(4),
+        0 1px 2px rgba(black, 0.05);
+    font-size: 85%;
+    min-width: rem(12px);
+    // We add 1px on the bottom to account for box-shadow
+    padding: rem(3px) rem(6px) calc(#{rem(3px)} + 1px);
+
+    &:backdrop {
+        background-image:
+            linear-gradient(
+                to bottom,
+                #{'alpha(@highlight_color, 0.3)'},
+                #{'alpha(@highlight_color, 0.35)'}
+            );
+    }
+}


### PR DESCRIPTION
![Screenshot from 2022-01-05 09 59 56](https://user-images.githubusercontent.com/7277719/148266053-7fec4126-19c9-4a7c-8cf0-ceab596e0aca.png)

There's still not toplevel selector, so we can't do anything about the headerbar style :(

* Fix window margin on Gtk.ShortcutWindow
* Remove `+` signs from Gtk.ShortcutLabel