### PR TITLE
GTK4: fix checkerboard

### DIFF
--- a/src/gtk-4.0/widgets/_index.scss
+++ b/src/gtk-4.0/widgets/_index.scss
@@ -13,18 +13,18 @@ selection {
     background-image:
         linear-gradient(
             45deg,
-            rgba(black, 0.1) 25%,
-            transparent 25%,
-            transparent 75%,
-            rgba(black, 0.1) 75%,
+            rgba(black, 0.1) rem(9px),
+            transparent rem(9px),
+            transparent rem(26px),
+            rgba(black, 0.1) rem(26px),
             rgba(black, 0.1)
         ),
         linear-gradient(
             45deg,
-            rgba(black, 0.1) 25%,
-            transparent 25%,
-            transparent 75%,
-            rgba(black, 0.1) 75%,
+            rgba(black, 0.1) rem(9px),
+            transparent rem(9px),
+            transparent rem(26px),
+            rgba(black, 0.1) rem(26px),
             rgba(black, 0.1)
         );
     background-size: rem(24px) rem(24px);


### PR DESCRIPTION
It looks like we get some funky aliasing when we use percentages that have the same value. Using pixels fixes this:

## BEFORE
![Screenshot from 2022-01-10 14 10 19](https://user-images.githubusercontent.com/7277719/148847051-1262353b-eb12-40cf-8765-ab8173fa1399.png)

## AFTER
![Screenshot from 2022-01-10 14 09 55](https://user-images.githubusercontent.com/7277719/148847055-a7d2e7c6-8f92-4ebd-a0a9-76915494e6f3.png)