### PR TITLE
GTK4/Windows: dialog tweaks

### DIFF
--- a/src/gtk-4.0/widgets/_windows.scss
+++ b/src/gtk-4.0/widgets/_windows.scss
@@ -102,13 +102,11 @@ window.dialog {
 
     .dialog-content-area {
         margin: rem(12px);
+        margin-top: rem(18px);
     }
 
-    // These should be 12px borders around buttons
     .dialog-action-area {
-        // Compensate for off-by-one
-        margin: rem(7px);
-        margin-bottom: rem(8px);
+        margin: rem(12px);
 
         button:dir(ltr) + button {
             margin-left: rem(6px);
@@ -119,8 +117,14 @@ window.dialog {
         }
     }
 
-    &.message .dialog-action-area {
-        // Double space between content and actions
-        margin-top: rem(16px);
+    &.message {
+        .dialog-content-area box + expander-widget {
+            margin-bottom: 6px;
+        }
+
+        .dialog-action-area {
+            // Double space between content and actions
+            margin-top: rem(16px);
+        }
     }
 }


### PR DESCRIPTION
This makes dialogs nearly identical to how they were in GTK3

## GTK3
![Screenshot from 2022-01-10 14 59 09](https://user-images.githubusercontent.com/7277719/148853904-d1da070a-0c06-4ba5-b82a-3a94aff331b6.png)

## GTK4
![Screenshot from 2022-01-10 15 17 26](https://user-images.githubusercontent.com/7277719/148853900-1fb8cc83-4428-47b9-a025-7bc8c1ddf64d.png)