### PR TITLE
GTK4/Entries: style date-picker and time-picker

### DIFF
--- a/src/gtk-4.0/widgets/_calendars.scss
+++ b/src/gtk-4.0/widgets/_calendars.scss
@@ -2,7 +2,10 @@ calendar.view {
     background: transparent;
 
     .day-name {
-        @extend .h4;
+        font-weight: 700;
+        opacity: 0.8;
+        padding-bottom: 0.5em;
+        padding-top: 0.5em;
     }
 
     .day-number {

--- a/src/gtk-4.0/widgets/_entries.scss
+++ b/src/gtk-4.0/widgets/_entries.scss
@@ -78,4 +78,12 @@ entry {
             min-width: rem(2px);
         }
     }
+
+    &.date-picker popover > contents {
+        padding: rem(6px);
+    }
+
+    &.time-picker popover > contents {
+        padding: rem(12px);
+    }
 }


### PR DESCRIPTION
Goes with: https://github.com/elementary/granite/pull/559

Fixes a bug with calendar widgets in popovers