### PR TITLE
GTK4/Popovers: fix modelmenu styles

### DIFF
--- a/src/gtk-4.0/widgets/_popovers.scss
+++ b/src/gtk-4.0/widgets/_popovers.scss
@@ -199,6 +199,43 @@ popover.background {
         separator {
             margin: rem(3px) 0;
         }
+
+        // ModelMenu
+        box.circular-buttons,
+        box.horizontal-buttons,
+        widget > scale {
+            margin: rem(6px) rem(12px);
+        }
+
+        widget:dir(ltr) > scale {
+            margin: rem(6px) rem(12px) rem(6px) rem(32px);
+        }
+
+        box.circular-buttons button.circular.image-button {
+            padding: rem(9px);
+        }
+
+        box.inline-buttons {
+            margin: rem(3px) rem(12px);
+
+            &:dir(ltr) button + button {
+                margin-left: rem(6px);
+            }
+        }
+
+        &:dir(ltr) box.inline-buttons label + box,
+        &:dir(ltr) modelbutton label + accelerator {
+            margin-left: rem(12px);
+        }
+
+        .title {
+            font-weight: 700;
+
+            &.separator {
+                margin: rem(6px) rem(32px);
+                opacity: 0.8;
+            }
+        }
     }
 
     modelbutton,


### PR DESCRIPTION
This fixes all the modelbutton styles in GTK4 Widget Factory, but only for LTR. It looks like RTL has a lot of other issues that I'd like to follow up on in future PRs

## BEFORE

![Screenshot from 2022-01-12 11 43 38](https://user-images.githubusercontent.com/7277719/149210905-3447d476-eb7d-42d6-9ee7-55f5143dd978.png)
![Screenshot from 2022-01-12 11 43 28](https://user-images.githubusercontent.com/7277719/149210906-2c8a911a-9b8c-46da-9243-cfecfa460ed3.png)
![Screenshot from 2022-01-12 11 43 13](https://user-images.githubusercontent.com/7277719/149210910-d6f83ba5-ae22-47dc-8ca2-a548dc05a66f.png)
![Screenshot from 2022-01-12 11 43 00](https://user-images.githubusercontent.com/7277719/149210912-bee2fd98-7deb-437f-ae3b-39cc8ef7cc96.png)

## AFTER
![Screenshot from 2022-01-12 11 42 26](https://user-images.githubusercontent.com/7277719/149210915-323cec77-247f-4bf5-ae4f-5f6e9dac8662.png)
![Screenshot from 2022-01-12 11 42 03](https://user-images.githubusercontent.com/7277719/149210919-7bd3adfa-88fe-4d1d-9fbc-3085fdf06465.png)
![Screenshot from 2022-01-12 11 41 46](https://user-images.githubusercontent.com/7277719/149210921-49a909d8-3a51-4df6-8464-11abc548ff5d.png)
![Screenshot from 2022-01-12 11 41 30](https://user-images.githubusercontent.com/7277719/149210924-b493fdfe-34c5-43dd-8cdd-ab788a5e20d1.png)