### PR TITLE
GTK4: fix link styles

### DIFF
--- a/src/gtk-4.0/_typography.scss
+++ b/src/gtk-4.0/_typography.scss
@@ -39,9 +39,7 @@ label.h4,
     font-size: 0.85em;
 }
 
-.accent,
-button.link,
-link {
+.accent {
     @if $color-scheme == "light" {
         color: #{'shade(@accent_color, 0.75)'};
     } @else if $color-scheme == "dark" {
@@ -136,6 +134,7 @@ link {
 
 button.link,
 link {
+    @extend .accent;
     text-decoration: underline;
 }
 

--- a/src/gtk-4.0/_typography.scss
+++ b/src/gtk-4.0/_typography.scss
@@ -40,8 +40,8 @@ label.h4,
 }
 
 .accent,
-.link,
-:link {
+button.link,
+link {
     @if $color-scheme == "light" {
         color: #{'shade(@accent_color, 0.75)'};
     } @else if $color-scheme == "dark" {
@@ -132,6 +132,11 @@ label.h4,
         color: $fg-color;
         opacity: 0.6;
     }
+}
+
+button.link,
+link {
+    text-decoration: underline;
 }
 
 .dim-label,


### PR DESCRIPTION
* Make sure we don't style the entire label with accent color when it contains a link
* Add underline to links