### PR TITLE
ModelButton: fix title-4 weight

### DIFF
--- a/src/gtk-4.0/_typography.scss
+++ b/src/gtk-4.0/_typography.scss
@@ -20,7 +20,8 @@
 label.h4,
 .h4 label,
 .heading,
-.title-4 {
+.title-4,
+.title-4 label {
     font-weight: 700;
     opacity: 0.8;
     padding-bottom: 0.5em;

--- a/src/gtk-4.0/widgets/_popovers.scss
+++ b/src/gtk-4.0/widgets/_popovers.scss
@@ -243,7 +243,8 @@ popover.background {
         @extend %menuitem;
 
         // Fixes extra padding in switch modelbuttons
-        &.h4 label {
+        &.h4 label,
+        &.title-4 label {
             padding: 0;
         }
     }


### PR DESCRIPTION
Fixes the font weight of labels in a `title-4` container, like Granite.SwitchModelButton