### PR TITLE
Sidebars: right border except in paned

### DIFF
--- a/src/gtk-4.0/widgets/_sidebars.scss
+++ b/src/gtk-4.0/widgets/_sidebars.scss
@@ -30,23 +30,29 @@
 }
 
 .sidebar {
-    list row,
+    &:dir(ltr) {
+        border-right: 1px solid #{'@menu_separator'};
+    }
+
+    &:dir(rtl) {
+        border-left: 1px solid #{'@menu_separator'};
+    }
+
+    paned.horizontal & {
+        &:dir(ltr) {
+            border-right: none;
+        }
+        &:dir(rtl) {
+            border-left: none;
+        }
+    }
+
+    row,
     // GtkAssistant
     > label {
         padding: rem(6px) rem(12px);
 
         @extend %sidebar-row;
-    }
-}
-
-assistant .sidebar {
-    &:dir(ltr) {
-        border-right: 1px solid #{'@menu_separator'};
-        box-shadow: inset -1px 0 0 #{'@menu_separator_shadow'};
-    }
-    &:dir(rtl) {
-        border-left: 1px solid #{'@menu_separator'};
-        box-shadow: inset 1px 0 0 #{'@menu_separator_shadow'};
     }
 }
 
@@ -89,9 +95,6 @@ settingssidebar list {
 }
 
 treeview.sidebar {
-    -GtkTreeView-horizontal-separator: 1px;
-    -GtkTreeView-vertical-separator: 6px;
-
     .view {
         @extend %sidebar-row;
     }


### PR DESCRIPTION
While we're here fix a terminal warning and style all rows. Fixes Gtk4 Demo, Assistant, and Inspector:

## BEFORE

![Screenshot from 2022-04-15 09 35 14](https://user-images.githubusercontent.com/7277719/163596755-0e9e75fa-9f99-49b0-9ac9-df82374b3a5f.png)
![Screenshot from 2022-04-15 09 35 08](https://user-images.githubusercontent.com/7277719/163596758-c03fe7ed-7042-4fad-a007-6f154ec87092.png)
![Screenshot from 2022-04-15 09 35 00](https://user-images.githubusercontent.com/7277719/163596760-d4ac2d33-1064-4134-a2ea-89d5de49a555.png)


## AFTER

![Screenshot from 2022-04-15 09 33 42](https://user-images.githubusercontent.com/7277719/163596631-34fd4446-8731-489d-a4a6-c77eec68942b.png)
![Screenshot from 2022-04-15 09 33 35](https://user-images.githubusercontent.com/7277719/163596633-a58e2336-8a52-461a-921f-5a1d603b83cf.png)
![Screenshot from 2022-04-15 09 32 56](https://user-images.githubusercontent.com/7277719/163596634-7a847127-ec6e-4c4a-ac23-903556a1e1d0.png)
