### PR TITLE
Lists: fix .title-4 padding

### DIFF
--- a/data/stylesheet.appdata.xml.in
+++ b/data/stylesheet.appdata.xml.in
@@ -14,6 +14,14 @@
     <id>io.elementary.stylesheet</id>
   </provides>
   <releases>
+    <release version="7.0.1" date="2022-05-26" urgency="medium">
+      <description>
+        <p>Fixes:</p>
+        <ul>
+          <li>Correct .title-4 padding in Lists</li>
+        </ul>
+      </description>
+    </release>
     <release version="7.0.0" date="2022-04-20" urgency="medium">
       <description>
         <p>New Features:</p>

--- a/src/gtk-4.0/widgets/_lists.scss
+++ b/src/gtk-4.0/widgets/_lists.scss
@@ -17,6 +17,7 @@ listview {
         }
     }
 
+    .title-4,
     .h4 {
         padding-left: rem(6px);
         padding-right: rem(6px);


### PR DESCRIPTION
We use the .title-* class in Granite now to follow Gtk4