### PR TITLE
use accent_color in highligth for all scales

### DIFF
--- a/src/gtk-3.0/widgets/_scales.scss
+++ b/src/gtk-3.0/widgets/_scales.scss
@@ -4,7 +4,7 @@ scale {
     }
 
     highlight {
-        background-color: rgba($fg-color, 0.7);
+        background-color: #{'accent_color'};
         border: 1px solid rgba(black, 0.3);
 
         box-shadow: inset 0 0 0 2px rgba(black, 0.03);

--- a/src/gtk-4.0/widgets/_scales.scss
+++ b/src/gtk-4.0/widgets/_scales.scss
@@ -4,7 +4,7 @@ scale {
     }
 
     highlight {
-        background-color: rgba($fg-color, 0.7);
+        background-color: #{'accent_color'};
         border: 1px solid rgba(black, 0.3);
 
         box-shadow: inset 0 0 0 2px rgba(black, 0.03);


### PR DESCRIPTION
Allows the user to change the highlight color for all scales with "accent_color", initially intended to resolve issue #947 

Result:
![image](https://user-images.githubusercontent.com/3580587/173706637-6c9efa02-92db-4f6a-85d2-6dbc2ef6897c.png)
