### PR TITLE
Button: inherited label properties

### DIFF
--- a/data/stylesheet.appdata.xml.in
+++ b/data/stylesheet.appdata.xml.in
@@ -19,6 +19,7 @@
         <p>Fixes:</p>
         <ul>
           <li>Correct .title-4 padding in Lists</li>
+          <li>Buttons: don't set font weight for children like popovers</li>
           <li>Headerbars: correct window control spacing in RTL, and separator width</li>
         </ul>
       </description>

--- a/src/gtk-4.0/widgets/_buttons.scss
+++ b/src/gtk-4.0/widgets/_buttons.scss
@@ -3,6 +3,7 @@ button {
     border-radius: rem(3px);
     // Explicitly set in case containers override default color
     color: #{'@fg_color'};
+    font-weight: 500;
     // Off-by-one to account for padding-box clip
     padding: rem(4px) rem(7px);
     transition: background duration("in-place") $easing;
@@ -83,10 +84,7 @@ button {
                 }
             }
 
-            image,
-            label {
-                color: inherit;
-            }
+            color: inherit;
 
             &:active,
             &:checked {
@@ -192,10 +190,6 @@ button {
         min-width: rem(16px);
         min-height: rem(16px);
         -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
-    }
-
-    label {
-        font-weight: 500;
     }
 
     &:dir(ltr) box image + label,

--- a/src/gtk-4.0/widgets/_buttons.scss
+++ b/src/gtk-4.0/widgets/_buttons.scss
@@ -84,8 +84,6 @@ button {
                 }
             }
 
-            color: inherit;
-
             &:active,
             &:checked {
                 @if $color-scheme == "light" {


### PR DESCRIPTION
We want to be very careful not to set properties on button children like labels and images because popovers will inherit those properties.

This fixes an issue where all the text inside popovers on menubuttons was incorrectly weighted