### PR TITLE
Menus/Popovers: dim disabled arrows, not shrink

### DIFF
--- a/src/gtk-3.0/widgets/_menus.scss
+++ b/src/gtk-3.0/widgets/_menus.scss
@@ -30,10 +30,7 @@
         }
 
         &:disabled {
-            border: none;
-            margin: 0;
-            min-height: 0;
-            min-width: 0;
+            color: $insensitive-fg-color;
         }
     }
 }

--- a/src/gtk-4.0/widgets/_popovers.scss
+++ b/src/gtk-4.0/widgets/_popovers.scss
@@ -144,10 +144,7 @@ popover.background {
             }
 
             &:disabled {
-                border: none;
-                margin: 0;
-                min-height: 0;
-                min-width: 0;
+                color: $insensitive-fg-color;
             }
         }
     }


### PR DESCRIPTION
Fixes #1216 
Superseded #1217 

This style applies to arrows for submenus as well as for the overflow arrows in long combobox menus, so we need to be careful about styling both.

Instead of "removing" disabled arrows, which causes issues with submenu arrows, we simply dim them