### PR TITLE
Gtk4/Scales: fix mark selector

### DIFF
--- a/src/gtk-4.0/widgets/_scales.scss
+++ b/src/gtk-4.0/widgets/_scales.scss
@@ -22,8 +22,8 @@ scale {
         }
     }
 
-    mark indicator {
-        color: mix(bg-color(4), $fg-color, $weight: 75%);
+    mark {
+        background: mix(bg-color(4), $fg-color, $weight: 75%);
     }
 
     slider {
@@ -156,7 +156,8 @@ scale {
             margin: -1px -1px -1px 0;
         }
 
-        mark indicator {
+        mark {
+            margin-top: rem(6px);
             min-height: rem(6px);
             // Intentionally not in ems since it's a stroke
             min-width: 1px;
@@ -186,7 +187,8 @@ scale {
             margin: 0 -1px -1px -1px;
         }
 
-        mark indicator {
+        mark {
+            margin-left: rem(6px);
             // Intentionally not in ems since it's a stroke
             min-height: 1px;
             min-width: rem(6px);

--- a/src/gtk-4.0/widgets/_scales.scss
+++ b/src/gtk-4.0/widgets/_scales.scss
@@ -156,8 +156,17 @@ scale {
             margin: -1px -1px -1px 0;
         }
 
+        marks {
+            &.bottom {
+                margin-top: rem(6px);
+            }
+
+            &.top {
+                margin-top: rem(6px);
+            }
+        }
+
         mark {
-            margin-top: rem(6px);
             min-height: rem(6px);
             // Intentionally not in ems since it's a stroke
             min-width: 1px;
@@ -187,8 +196,17 @@ scale {
             margin: 0 -1px -1px -1px;
         }
 
+        marks {
+            &.bottom {
+                margin-left: rem(6px);
+            }
+
+            &.top {
+                margin-right: rem(6px);
+            }
+        }
+
         mark {
-            margin-left: rem(6px);
             // Intentionally not in ems since it's a stroke
             min-height: 1px;
             min-width: rem(6px);


### PR DESCRIPTION
Fixes #1219

It looks like vertical scale marks are always on the right, even in RTL so we don't need to account for that