### PR TITLE
HeaderBars: set large-icons size to 24px

### DIFF
--- a/src/gtk-4.0/widgets/_headerbars.scss
+++ b/src/gtk-4.0/widgets/_headerbars.scss
@@ -45,7 +45,6 @@ window {
             -gtk-icon-shadow: none;
         }
 
-        &.large-icons,
         .large-icons {
             -gtk-icon-size: 24px;
         }

--- a/src/gtk-4.0/widgets/_headerbars.scss
+++ b/src/gtk-4.0/widgets/_headerbars.scss
@@ -44,6 +44,11 @@ window {
             text-shadow: none;
             -gtk-icon-shadow: none;
         }
+
+        &.large-icons,
+        .large-icons {
+            -gtk-icon-size: 24px;
+        }
     }
 
     &.csd {

--- a/src/gtk-4.0/widgets/_images.scss
+++ b/src/gtk-4.0/widgets/_images.scss
@@ -7,12 +7,12 @@ image {
     &:disabled {
         filter: opacity($disabled-opacity);
     }
+}
 
-    &.normal-icons {
-        -gtk-icon-size: 16px;
-    }
+.normal-icons {
+    -gtk-icon-size: 16px;
+}
 
-    &.large-icons {
-        -gtk-icon-size: 32px;
-    }
+.large-icons {
+    -gtk-icon-size: 32px;
 }


### PR DESCRIPTION
Makes my life easier to set icon sizes for buttons and menu buttons in titlebars. Especially for menubuttons since manually setting the child means no image-button class and it isn't easy to select the button since the popover is also a child. `has_frame` technically works here, but it adds `flat` which is slightly different from `image-button`.

Also in `images`, don't require the `large-icons` class to be directly on an image, because it's useful to set it on a container widget like a button

Vala before:
```vala
        var updates_button = new Gtk.Button.from_icon_name ("software-update-available");
        ((Gtk.Image) updates_button.child).pixel_size = 24;

        var menu_button = new Gtk.MenuButton () {
            child = new Gtk.Image.from_icon_name ("open-menu") {
                pixel_size = 24
            },
            has_frame = false
        };
```

Vala after:
```vala
        var updates_button = new Gtk.Button.from_icon_name ("software-update-available");
        updates_button.add_css_class ("large-icons");

        var menu_button = new Gtk.MenuButton () {
            icon_name = "open-menu",
        };
        menu_button.add_css_class ("large-icons");
```