### PR TITLE
SpinButtons: give padding to direct image children

### DIFF
--- a/src/gtk-4.0/widgets/_spinbuttons.scss
+++ b/src/gtk-4.0/widgets/_spinbuttons.scss
@@ -32,6 +32,10 @@ spinbutton {
             }
         }
 
+        > image {
+            padding: 0 rem(4px);
+        }
+
         text {
             margin: 0 rem(6px);
         }


### PR DESCRIPTION
Since SpinButton is no longer an Entry subclass it doesn't have the icon properties and you have to parent Images manually. This makes sure we give those Images padding like they would get in Gtk.Entry