### PR TITLE
SimpleSettingsPage: adjust header layout and text size

### DIFF
--- a/src/gtk-4.0/widgets/_settingspages.scss
+++ b/src/gtk-4.0/widgets/_settingspages.scss
@@ -7,22 +7,37 @@ simplesettingspage {
         margin-bottom: rem(24px);
 
         > image {
-            -gtk-icon-size: 48px;
+            -gtk-icon-size: rem(48px);
 
             &:dir(ltr) {
-                margin-right: rem(12px);
+                // Match square icon canvas whitespace at 48px
+                margin-left: rem(-4px);
+                margin-right: rem(7px);
             }
 
             &:dir(rtl) {
-                margin-left: rem(12px);
+                margin-left: rem(7px);
+                margin-right: rem(-4px);
             }
         }
 
+        label.title-2 {
+            font-weight: 600;
+            font-size: 2rem;
+        }
+
         label:not(.title-2) {
-            margin-top: rem(3px);
+            font-size: 0.95rem;
+            opacity: 0.85;
         }
 
         switch {
+            slider {
+                // Match font size for title
+                min-height: 2rem;
+                min-width: 2rem;
+            }
+
             &:dir(ltr) {
                 margin-left: rem(12px);
             }


### PR DESCRIPTION
* Make titles bold, more modern. Super thin title text is kinda out of style
* Match switch size to title text height
* Adjust icon padding for canvas white space (see with square icon at the bottom)
* Make description text slightly smaller and lighter


## BEFORE
![Screenshot from 2022-09-07 08 16 22](https://user-images.githubusercontent.com/7277719/188915826-38487b3a-59fc-4f60-b902-e331892c21a6.png)
![Screenshot from 2022-09-07 08 16 08](https://user-images.githubusercontent.com/7277719/188915836-bcd90875-aa8e-4798-9204-5f5cef19f87f.png)

## AFTER
![Screenshot from 2022-09-07 08 11 23](https://user-images.githubusercontent.com/7277719/188915840-9ed8b7b0-9e05-4e21-8a78-7883b91fba7c.png)
![Screenshot from 2022-09-07 08 09 37](https://user-images.githubusercontent.com/7277719/188915850-e936a0ea-1292-44fc-9946-754673991054.png)

Demonstrating that the edges of tile icons line up with the frame now:
![Screenshot from 2022-09-07 08 08 46](https://user-images.githubusercontent.com/7277719/188915853-2ce399ea-b05a-44f0-95cd-cfd91989586b.png)