### PR TITLE
Gtk4/Popovers: style completion-entry

### DIFF
--- a/data/stylesheet.appdata.xml.in
+++ b/data/stylesheet.appdata.xml.in
@@ -22,6 +22,7 @@
           <li>Set `large-icons` size on headerbars to 24px</li>
           <li>Adjust header layout and typography in Granite.SimpleSettingsPage</li>
           <li>Infobars: set correct button margins</li>
+          <li>Add padding to Gtk.Entry's completion popover</li>
         </ul>
         <p>Fixes:</p>
         <ul>

--- a/src/gtk-4.0/widgets/_popovers.scss
+++ b/src/gtk-4.0/widgets/_popovers.scss
@@ -149,6 +149,14 @@ popover.background {
         }
     }
 
+    &.entry-completion > contents treeview {
+        margin: rem(6px) 0;
+
+        &.view.cell {
+            padding: rem(6px) rem(12px);
+        }
+    }
+
     &.menu > contents {
         box-shadow:
             outset-highlight(),


### PR DESCRIPTION
Fixes lack of padding in completion entry menus

## BEFORE
![Screenshot from 2022-09-27 11 02 50](https://user-images.githubusercontent.com/7277719/192602632-719e7ea4-c132-44e5-949d-a4e59b7f5c0e.png)

## AFTER
![Screenshot from 2022-09-27 11 02 23](https://user-images.githubusercontent.com/7277719/192602638-c00bba5a-f62f-4901-b215-35ce8415932c.png)