### PR TITLE
CheckButtons: set margin on check/radio element

### DIFF
--- a/src/gtk-4.0/widgets/_checkbuttons.scss
+++ b/src/gtk-4.0/widgets/_checkbuttons.scss
@@ -12,6 +12,14 @@ radio {
     -gtk-icon-source: none;
     -gtk-icon-size: rem(12px);
 
+    &:dir(ltr) {
+        margin-right: rem(6px);
+    }
+
+    &:dir(rtl) {
+        margin-left: rem(6px);
+    }
+
     &:checked {
         background-color: #{'@accent_color'};
         color: white;
@@ -63,17 +71,6 @@ radio {
 }
 
 checkbutton {
-    image,
-    label {
-        &:dir(ltr) {
-            margin-left: rem(6px);
-        }
-
-        &:dir(rtl) {
-            margin-right: rem(6px);
-        }
-    }
-
     &.image-button {
         // Invisible stroke to prevent things from moving when :checked
         border: 1px solid transparent;


### PR DESCRIPTION
Fixes an issue where image children of checkbuttons have extra margins. Normal case is unchanged

## BEFORE
![Screenshot from 2022-09-27 17 29 10](https://user-images.githubusercontent.com/7277719/192660962-0897884b-229a-4da3-83da-9a20d40954da.png)
![Screenshot from 2022-09-27 17 18 41](https://user-images.githubusercontent.com/7277719/192660974-d8db1623-1959-4283-8aeb-eeeceecfe791.png)

## AFTER
![Screenshot from 2022-09-27 17 28 10](https://user-images.githubusercontent.com/7277719/192660965-d8931f07-4b55-44f8-92cc-361d2aba084b.png)

The extra padding between the check and entry here is now an issue with the plug since it's adding its own 6px margin to try to make up for the previously missing margin in the stylesheet
![Screenshot from 2022-09-27 17 25 12](https://user-images.githubusercontent.com/7277719/192660970-7f797c84-4291-4315-baf8-cb741b9061a5.png)