### PR TITLE
Add 3px of padding check, radio to match setting > desktop > appearance

### DIFF
--- a/src/gtk-3.0/widgets/_checkbuttons.scss
+++ b/src/gtk-3.0/widgets/_checkbuttons.scss
@@ -1,6 +1,7 @@
 check,
 radio {
     @extend %outset-background;
+    padding: rem(3px);
     background-color: bg-color(0);
     border: 1px solid $border-color;
     box-shadow:

--- a/src/gtk-4.0/widgets/_checkbuttons.scss
+++ b/src/gtk-4.0/widgets/_checkbuttons.scss
@@ -1,6 +1,7 @@
 check,
 radio {
     @extend %outset-background;
+    padding: rem(3px);
     background-color: bg-color(0);
     border: 1px solid $border-color;
     box-shadow:


### PR DESCRIPTION
### **Before:**
![Screenshot from 2023-02-21 20-30-55](https://user-images.githubusercontent.com/2386630/220497636-c7fcb536-aab8-4bba-bad1-fc67f3f8a271.png)
### **After:**
![Screenshot from 2023-02-21 20-28-22](https://user-images.githubusercontent.com/2386630/220497519-2b2e88ea-ae70-4fa0-a091-6cb1fb134a27.png)

I  also believe radio button should use a circle when checked instead of a checkmark 

