### PR TITLE
GTK4: Support `.keyboard-activating` class for buttons

### DIFF
--- a/src/gtk-4.0/widgets/_buttons.scss
+++ b/src/gtk-4.0/widgets/_buttons.scss
@@ -56,6 +56,7 @@ button {
                     background-clip: border-box;
                     border: 1px solid $border-color;
                 } @else if $color-scheme == "dark" {
+                    &.keyboard-activating,
                     &:active,
                     &:checked {
                         border-color: rgba(black, 0.7);
@@ -84,6 +85,7 @@ button {
                 }
             }
 
+            &.keyboard-activating,
             &:active,
             &:checked {
                 @if $color-scheme == "light" {
@@ -94,6 +96,7 @@ button {
             }
         }
 
+        &.keyboard-activating,
         &:active,
         &:checked {
             background: rgba(black, 0.05);


### PR DESCRIPTION
See https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/3390

I guess this class needs to be used in some other places, but this is bare minimum for https://github.com/elementary/calculator/pull/242