### PR TITLE
Headerbars: fix missing default-decoration

### DIFF
--- a/src/gtk-4.0/widgets/_headerbars.scss
+++ b/src/gtk-4.0/widgets/_headerbars.scss
@@ -84,6 +84,10 @@ headerbar {
                 0 1px rem(2px) rgba(black, 0.15);
         }
 
+        &.default-decoration {
+            padding: rem(3px);
+        }
+
         &.flat {
             background: inherit;
             color: inherit;


### PR DESCRIPTION
Somehow missed this in the last release