### PR TITLE
ToolbarView: add bottom-bar styles

### DIFF
--- a/data/stylesheet.appdata.xml.in
+++ b/data/stylesheet.appdata.xml.in
@@ -23,7 +23,7 @@
   <url type="bugtracker">https://github.com/elementary/stylesheet/issues</url>
 
   <releases>
-    <release version="8.0.1" date="2024-05-12" urgency="medium">
+    <release version="8.1.0" date="2024-05-12" urgency="medium">
       <description>
         <p>Improve support for LibAdwaita widgets:</p>
         <ul>

--- a/data/stylesheet.appdata.xml.in
+++ b/data/stylesheet.appdata.xml.in
@@ -24,6 +24,12 @@
 
   <releases>
     <release version="8.0.1" date="2024-05-12" urgency="medium">
+      <description>
+        <p>Improve support for LibAdwaita widgets:</p>
+        <ul>
+          <li>Adw.ToolbarView: add "bottom-bar" styles for "raised" and "border"</li>
+        </ul>
+      </description>
       <issues>
         <issue url="https://github.com/elementary/stylesheet/issues/1291">Tabs on Epiphany camouflague with the new flat header</issue>
       </issues>

--- a/src/gtk-4.0/widgets/adw/ToolbarView.scss
+++ b/src/gtk-4.0/widgets/adw/ToolbarView.scss
@@ -76,4 +76,40 @@ toolbarview {
                 0 1px 0 0 #{'alpha(@borders, 0.8)'};
         }
     }
+
+    revealer.bottom-bar {
+        &.raised {
+            background-color: rgba(black, 0.01);
+            background-image:
+                linear-gradient(
+                    to bottom,
+                    $border-color 1px,
+                    rgba(black, 0.07) 1px,
+                    transparent rem(3px)
+                );
+            box-shadow: 0 -1px #{'alpha(@highlight_color, 0.2)'};
+
+            &:backdrop {
+                background-image:
+                    linear-gradient(
+                        to bottom,
+                        $border-color 1px,
+                        rgba(black, 0.04) 1px,
+                        transparent rem(3px)
+                    );
+                box-shadow: none;
+            }
+        }
+
+        &.raised.border {
+            background: rgba(black, 0.03);
+            box-shadow:
+                0 -1px #{'@borders'},
+                inset 0 1px #{'alpha(@highlight_color, 0.3)'};
+        }
+
+        actionbar {
+            padding: rem(6px);
+        }
+    }
 }


### PR DESCRIPTION
I've used this twice now in Switchboard and in Music. Better replacement for `.inline-toolbar`

![Screenshot from 2024-05-14 15 12 18](https://github.com/elementary/stylesheet/assets/7277719/3f53d08d-5839-42f8-95ae-6284cf62573d)