### PR TITLE
Popover: fix indentation for headerlabel

### DIFF
--- a/src/gtk-4.0/widgets/_popovers.scss
+++ b/src/gtk-4.0/widgets/_popovers.scss
@@ -77,7 +77,7 @@ popover.background {
     > contents {
         border-radius: rem(6px);
 
-        label.heading,
+        header,
         label.h4 {
             margin: 0 rem(12px);
         }
@@ -159,6 +159,15 @@ popover.background {
             outset-highlight(),
             shadow(2);
         padding: rem(6px) 0;
+
+        label.heading {
+            margin: 0 rem(12px);
+        }
+
+        // Don't double indent labels in Granite.HeaderLabel
+        header label.heading {
+            margin: 0;
+        }
 
         popover {
             box-shadow:


### PR DESCRIPTION
* `label.heading` is used by Gtk.PopoverMenu so only style it when its in a `popover.menu` node. 
* `header` is the node used by Granite.HeaderLabel so replace this in `popover` to avoid regressions
* Make sure we clear indentation on `header label.heading` (the primary label in a Granite.HeaderLabel` so we don't end up with double indentation

## BEFORE
![Screenshot from 2025-07-08 09 55 08](https://github.com/user-attachments/assets/e8a712ca-40d1-436d-9c81-4a6a917cdd06)

## AFTER
![Screenshot from 2025-07-08 09 58 59](https://github.com/user-attachments/assets/836bda0d-a9b7-4773-852b-2c09dc58fa82)