### PR TITLE
Show sort-indicator in treeviews

### DIFF
--- a/src/gtk-4.0/widgets/_treeviews.scss
+++ b/src/gtk-4.0/widgets/_treeviews.scss
@@ -33,5 +33,18 @@ treeview {
         &:backdrop label {
             opacity: 0.6;
         }
+
+        sort-indicator {
+            min-height: 16px;
+            min-width: 16px;
+
+            &.ascending {
+                -gtk-icon-source: -gtk-icontheme("pan-down-symbolic");
+            }
+
+            &.descending {
+                -gtk-icon-source: -gtk-icontheme("pan-up-symbolic");
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #1273

This fixes sort indicators are not being shown in TreeViews.
Affected  https://github.com/elementary/monitor/pull/443

Special thanks to @Marukesu for diagnostics.