### PR TITLE
focus → focus-visible

### DIFF
--- a/src/gtk-4.0/widgets/_badges.scss
+++ b/src/gtk-4.0/widgets/_badges.scss
@@ -45,7 +45,7 @@
         min-height: 0;
         min-width: rem(16px);
 
-        row:selected:not(:focus) & {
+        row:selected:not(:focus-visible) & {
             color: inherit;
             background: rgba($fg-color, 0.15);
         }

--- a/src/gtk-4.0/widgets/_buttons.scss
+++ b/src/gtk-4.0/widgets/_buttons.scss
@@ -18,7 +18,7 @@ button {
             background: rgba($fg-color, 0.15);
         }
 
-        &:focus {
+        &:focus-visible {
             @extend selection;
             outline-style: none;
         }
@@ -52,7 +52,7 @@ button {
         &.destructive-action:not(:disabled) {
 
             &,
-            &:focus {
+            &:focus-visible {
                 @if $color-scheme == "light" {
                     background-clip: border-box;
                     border-color: $border-color;
@@ -70,7 +70,7 @@ button {
             text-shadow: 0 1px 1px $STRAWBERRY_500;
             -gtk-icon-shadow: 0 1px 1px $STRAWBERRY_500;
 
-            &:focus {
+            &:focus-visible {
                 outline-color: rgba($STRAWBERRY_300, 0.5);
             }
         }
@@ -115,7 +115,7 @@ button {
                 outset-shadow(1);
         }
 
-        &:focus {
+        &:focus-visible {
             @if $color-scheme == "light" {
                 border-color: #{'@accent_color'};
             }

--- a/src/gtk-4.0/widgets/_checkbuttons.scss
+++ b/src/gtk-4.0/widgets/_checkbuttons.scss
@@ -48,7 +48,7 @@ radio {
         -gtk-icon-source: -gtk-icontheme("check-mixed-symbolic");
     }
 
-    &:focus {
+    &:focus-visible {
         &:not(:checked) {
             @if $color-scheme == "light" {
                 border-color: #{'@accent_color'};

--- a/src/gtk-4.0/widgets/_columnviews.scss
+++ b/src/gtk-4.0/widgets/_columnviews.scss
@@ -39,7 +39,7 @@ columnview {
                 background: rgba($fg-color, 0.15);
             }
 
-            &:focus:selected {
+            &:focus-visible:selected {
                 @extend selection;
             }
         }

--- a/src/gtk-4.0/widgets/_lists.scss
+++ b/src/gtk-4.0/widgets/_lists.scss
@@ -7,12 +7,12 @@ listview {
     }
 
     row {
-        &:focus,
+        &:focus-visible,
         &:selected {
             background: rgba($fg-color, 0.15);
         }
 
-        &:focus:selected {
+        &:focus-visible:selected {
             @extend selection;
         }
     }

--- a/src/gtk-4.0/widgets/_scales.scss
+++ b/src/gtk-4.0/widgets/_scales.scss
@@ -227,7 +227,7 @@ scale {
         }
     }
 
-    &:focus slider {
+    &:focus-visible slider {
         @if $color-scheme == "light" {
             box-shadow:
                 outset-highlight("full"),

--- a/src/gtk-4.0/widgets/_switches.scss
+++ b/src/gtk-4.0/widgets/_switches.scss
@@ -73,7 +73,7 @@ switch {
         }
     }
 
-    &:focus {
+    &:focus-visible {
         @if $color-scheme == "light" {
             border-color: #{'@accent_color'};
         }

--- a/src/gtk-4.0/widgets/_treeviews.scss
+++ b/src/gtk-4.0/widgets/_treeviews.scss
@@ -4,7 +4,7 @@ treeview {
             background: rgba($fg-color, 0.15);
         }
 
-        &:focus:selected {
+        &:focus-visible:selected {
             @extend selection;
         }
     }

--- a/src/gtk-4.0/widgets/_views.scss
+++ b/src/gtk-4.0/widgets/_views.scss
@@ -14,7 +14,7 @@ iconview.view.cell {
         background: rgba($fg-color, 0.15);
     }
 
-    &:focus:selected {
+    &:focus-visible:selected {
         @extend selection;
     }
 }
@@ -23,12 +23,12 @@ gridview child,
 flowboxchild {
     border-radius: rem(3px);
 
-    &:focus,
+    &:focus-visible,
     &:selected {
         background: rgba($fg-color, 0.15);
     }
 
-    &:focus:selected {
+    &:focus-visible:selected {
         @extend selection;
     }
 }


### PR DESCRIPTION
Fixes #1055
Fixes #1069

Changes use of `focus` to `focus-visible.

Widgets no longer get focus styles when clicked or on app startup, just when keyboard navigation is being used. And focus styles disappear after a little bit